### PR TITLE
[MCC-259892] Change MAuthSigningHandler options to MAuthSigningOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changes in Medidata.MAuth
+
+## v2.0.0
+- **[Medidata.MAuth.Core]** The `MAuthSigningHandler` is accepting an `MAuthSigningOptions` instance instead of
+an `MAuthOptions` instance (which in turn set to be an abstract class)
+- [**Medidata.MAuth.Owin]** The OWIN middleware infrastructure provided request body stream gets replaced 
+with a `MemoryStream` in cases when the original body stream is not seekable.
+
+## v1.0.0
+- Initial version

--- a/GlobalAssemblyInfo.cs
+++ b/GlobalAssemblyInfo.cs
@@ -14,6 +14,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyInformationalVersion("2.0.0")]

--- a/Medidata.MAuth.sln
+++ b/Medidata.MAuth.sln
@@ -5,6 +5,7 @@ VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{32B2C923-2DAE-4E48-9671-00636E159896}"
 	ProjectSection(SolutionItems) = preProject
+		CHANGELOG.md = CHANGELOG.md
 		LICENSE.md = LICENSE.md
 		README.md = README.md
 	EndProjectSection

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cases.
 ### Signing Outgoing Requests
 
 In order to sign outgoing requests, an `MAuthSigningHandler` class is provided in the Core package. this handler
-accepts an `MAuthOptions` instance which stores all the necessary settings for MAuth.
+accepts an `MAuthSigningOptions` instance which stores all the necessary settings for the signing process.
 
 An example:
 
@@ -91,7 +91,7 @@ using Medidata.MAuth.Core;
 
 public async Task<HttpResponseMessage> SignAndSendRequest(HttpRequestMessage request)
 {
-	var signingHandler = new MAuthSigningHandler(new MAuthOptions()
+	var signingHandler = new MAuthSigningHandler(new MAuthSigningOptions()
 	{
 		ApplicationUuid = new Guid("7c872d75-986b-4c61-bb17-f2569d42bfb0"),
 		PrivateKey = File.ReadAllText("ClientPrivateKey.pem")
@@ -107,7 +107,7 @@ public async Task<HttpResponseMessage> SignAndSendRequest(HttpRequestMessage req
 The example above is creating a new instance of a `HttpClient` with the handler responsible for signing the
 requests and sends the request to its designation. Finally it returns the response from the remote server.
 
-The `MAuthOptions` has the following properties to determine the required settings:
+The `MAuthSigningOptions` has the following properties to determine the required settings:
 
 | Name | Description |
 | ---- | ----------- |
@@ -238,4 +238,17 @@ so in the near future there is a possibility that we will add a new package with
 ##### What Cryptographic provider is used for the encryption/decryption?
 
 We are using the latest version (as of date 1.81) of the [BouncyCastle](https://github.com/bcgit/bc-csharp) library.
+
+##### What are the major changes in the 2.0.0 version?
+
+In this version we have only one major and a minor change: from this version the `MAuthSigningHandler` is accepting an
+`MAuthSigningOptions` instance instead of an `MAuthOptions` instance (which in turn set to be an abstract class).
+This change was necessary because the MAuthOptions object contains the `MAuthServiceUrl` property, which is not required
+for signing, but it had to be set to a valid Url nonetheless.
+
+The other underlying change is that in the OWIN middleware the infrastructure provided request body stream gets replaced
+with a `MemoryStream` in cases when the original body stream is not seekable. This change was necessary, because in
+order to authenticate the request we need to read the body, but if the body stream is not seekable we are not able to
+restore it for the subsequent middlewares to read. Typical example for this is when the OWIN selfhost infrastructure
+is used as it wraps the original stream in a non-seekable version.
 

--- a/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
+++ b/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
@@ -11,29 +11,29 @@ namespace Medidata.MAuth.Core
     /// </summary>
     public class MAuthSigningHandler: DelegatingHandler
     {
-        private readonly MAuthAuthenticator authenticator;
+        private readonly MAuthSigningOptions options;
 
         /// <summary>Gets the Uuid of the client application.</summary>
-        public Guid ClientAppUuid => authenticator.ApplicationUuid;
+        public Guid ClientAppUuid => options.ApplicationUuid;
 
         /// <summary>
         /// Initializes a new insance of the <see cref="MAuthSigningHandler"/> class with the provided
-        /// <see cref="MAuthOptions"/>.
+        /// <see cref="MAuthSigningOptions"/>.
         /// </summary>
         /// <param name="options">The options for this message handler.</param>
-        public MAuthSigningHandler(MAuthOptions options): this(options, new HttpClientHandler()) { }
+        public MAuthSigningHandler(MAuthSigningOptions options): this(options, new HttpClientHandler()) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MAuthSigningHandler"/> class with the provided
-        /// <see cref="MAuthOptions"/> and an inner <see cref="HttpMessageHandler"/>. 
+        /// <see cref="MAuthSigningOptions"/> and an inner <see cref="HttpMessageHandler"/>. 
         /// </summary>
         /// <param name="options">The options for this message handler.</param>
         /// <param name="innerHandler">
         /// The inner handler which is responsible for processing the HTTP response messages.
         /// </param>
-        public MAuthSigningHandler(MAuthOptions options, HttpMessageHandler innerHandler): base(innerHandler)
+        public MAuthSigningHandler(MAuthSigningOptions options, HttpMessageHandler innerHandler): base(innerHandler)
         {
-            authenticator = new MAuthAuthenticator(options);
+            this.options = options;
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace Medidata.MAuth.Core
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
             return await base
-                .SendAsync(await authenticator.SignRequest(request), cancellationToken)
+                .SendAsync(await request.Sign(options), cancellationToken)
                 .ConfigureAwait(continueOnCapturedContext: false);
         }
     }

--- a/src/Medidata.MAuth.Core/Medidata.MAuth.Core.csproj
+++ b/src/Medidata.MAuth.Core/Medidata.MAuth.Core.csproj
@@ -61,7 +61,8 @@
     <Compile Include="MAuthAuthenticator.cs" />
     <Compile Include="MAuthCoreExtensions.cs" />
     <Compile Include="MAuthSigningHandler.cs" />
-    <Compile Include="MAuthOptions.cs" />
+    <Compile Include="Options\MAuthOptionsBase.cs" />
+    <Compile Include="Options\MAuthSigningOptions.cs" />
     <Compile Include="Models\ApplicationInfo.cs" />
     <Compile Include="Models\PrivateKeyAuthenticationInfo.cs" />
     <Compile Include="Models\PayloadAuthenticationInfo.cs" />

--- a/src/Medidata.MAuth.Core/Medidata.MAuth.Core.nuspec
+++ b/src/Medidata.MAuth.Core/Medidata.MAuth.Core.nuspec
@@ -12,6 +12,7 @@
     <licenseUrl>https://github.com/mdsol/mauth-client-dotnet/blob/master/LICENSE.md</licenseUrl>
     <summary>$description$</summary>
     <description>A core package for Medidata HMAC protocol implementation. This package contains the core functionality which used by the MAuth authentication protocol-specific components. This package also can be used standalone if you want to sign HTTP/HTTPS requests with Medidata MAuth keys using the .NET HttpClient message handler mechanism.</description>
+    <releaseNotes>This version introduces the MAuthSigningOptions options object instead of the MAuthOptions for the MAuthSigningHandler. With this change the handler does not need the MAuth server url for its configuration anymore.</releaseNotes>
     <copyright>$copyright$</copyright>
     <tags>medidata mauth hmac authentication core httpclient messagehandler</tags>
   </metadata>

--- a/src/Medidata.MAuth.Core/Options/MAuthOptionsBase.cs
+++ b/src/Medidata.MAuth.Core/Options/MAuthOptionsBase.cs
@@ -6,7 +6,7 @@ namespace Medidata.MAuth.Core
     /// <summary>
     /// Contains the options used by the <see cref="MAuthAuthenticator"/>.
     /// </summary>
-    public class MAuthOptions
+    public abstract class MAuthOptionsBase
     {
         /// <summary>Determines the RSA private key for the authentication requests.</summary>
         public string PrivateKey { get; set; }
@@ -23,12 +23,6 @@ namespace Medidata.MAuth.Core
         /// value will be 10 seconds.
         /// </summary>
         public int AuthenticateRequestTimeoutSeconds { get; set; } = 10;
-
-        /// <summary>
-        /// Determines the time when signing requests instead of the current date and time.
-        /// This property is for testing purposes only.
-        /// </summary>
-        internal DateTimeOffset? SignedTime { get; set; }
 
         /// <summary>
         /// Determines the message handler for the requests to the MAuth server.

--- a/src/Medidata.MAuth.Core/Options/MAuthSigningOptions.cs
+++ b/src/Medidata.MAuth.Core/Options/MAuthSigningOptions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Medidata.MAuth.Core
+{
+    /// <summary>
+    /// Contains the options used by the <see cref="MAuthSigningHandler"/>.
+    /// </summary>
+    public class MAuthSigningOptions
+    {
+        /// <summary>Determines the RSA private key for the authentication requests.</summary>
+        public string PrivateKey { get; set; }
+
+        /// <summary>Determines the unique identifier used for the MAuth service authentication requests.</summary>
+        public Guid ApplicationUuid { get; set; }
+
+        /// <summary>
+        /// Determines the time when signing requests instead of the current date and time.
+        /// This property is for testing purposes only.
+        /// </summary>
+        internal DateTimeOffset? SignedTime { get; set; }
+    }
+}

--- a/src/Medidata.MAuth.Owin/MAuthMiddleware.cs
+++ b/src/Medidata.MAuth.Owin/MAuthMiddleware.cs
@@ -1,4 +1,8 @@
-﻿using System.Net;
+﻿using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Mime;
+using System.Text;
 using System.Threading.Tasks;
 using Medidata.MAuth.Core;
 using Microsoft.Owin;
@@ -18,6 +22,8 @@ namespace Medidata.MAuth.Owin
 
         public override async Task Invoke(IOwinContext context)
         {
+            await context.EnsureRequestBodyStreamSeekable();
+
             if (!options.Bypass(context.Request) &&
                 !await context.TryAuthenticate(authenticator, options.HideExceptionsAndReturnForbidden))
             {

--- a/src/Medidata.MAuth.Owin/MAuthMiddlewareOptions.cs
+++ b/src/Medidata.MAuth.Owin/MAuthMiddlewareOptions.cs
@@ -7,7 +7,7 @@ namespace Medidata.MAuth.Owin
     /// <summary>
     /// Contains the options used by the <see cref="MAuthMiddleware"/>.
     /// </summary>
-    public class MAuthMiddlewareOptions: MAuthOptions
+    public class MAuthMiddlewareOptions: MAuthOptionsBase
     {
          /// <summary>
         /// Determines if the middleware should swallow all exceptions and return an empty HTTP response with a

--- a/src/Medidata.MAuth.Owin/Medidata.MAuth.Owin.nuspec
+++ b/src/Medidata.MAuth.Owin/Medidata.MAuth.Owin.nuspec
@@ -12,6 +12,7 @@
     <licenseUrl>https://github.com/mdsol/mauth-client-dotnet/blob/master/LICENSE.md</licenseUrl>
     <summary>$description$</summary>
     <description>This package contains an OWIN middleware to validate signed http requests with the Medidata MAuth protocol. The middleware communicates with an MAuth server in order to confirm the validity of the request authentication header. Include this package in your OWIN-enabled web api if you want to authenticate the api requests signed with the MAuth protocol.</description>
+    <releaseNotes>This version makes possible to read the OWIN request body in the subsequent middlewares after the authentication, even if the body stream is not seekable initially.</releaseNotes>
     <copyright>$copyright$</copyright>
     <tags>medidata mauth hmac authentication core owin middleware webapi</tags>
   </metadata>

--- a/src/Medidata.MAuth.WebApi/MAuthAuthenticatingHandler.cs
+++ b/src/Medidata.MAuth.WebApi/MAuthAuthenticatingHandler.cs
@@ -28,7 +28,7 @@ namespace Medidata.MAuth.WebApi
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MAuthAuthenticatingHandler"/> class with the provided
-        /// <see cref="MAuthOptions"/> and an inner <see cref="HttpMessageHandler"/>. 
+        /// <see cref="MAuthOptionsBase"/> and an inner <see cref="HttpMessageHandler"/>. 
         /// </summary>
         /// <param name="options">The options for this message handler.</param>
         /// <param name="innerHandler">

--- a/src/Medidata.MAuth.WebApi/MAuthWebApiOptions.cs
+++ b/src/Medidata.MAuth.WebApi/MAuthWebApiOptions.cs
@@ -5,7 +5,7 @@ namespace Medidata.MAuth.WebApi
     /// <summary>
     /// Contains the options used by the <see cref="MAuthAuthenticatingHandler"/>.
     /// </summary>
-    public class MAuthWebApiOptions: MAuthOptions
+    public class MAuthWebApiOptions: MAuthOptionsBase
     {
          /// <summary>
         /// Determines if the message handler should swallow all exceptions and return an empty HTTP response with a

--- a/src/Medidata.MAuth.WebApi/Medidata.MAuth.WebApi.nuspec
+++ b/src/Medidata.MAuth.WebApi/Medidata.MAuth.WebApi.nuspec
@@ -12,6 +12,7 @@
     <licenseUrl>https://github.com/mdsol/mauth-client-dotnet/blob/master/LICENSE.md</licenseUrl>
     <summary>$description$</summary>
     <description>This package contains an HTTP message handler to validate signed http requests with the Medidata MAuth protocol. The handler communicates with an MAuth server in order to confirm the validity of the request authentication header. Include this package in your WebAPI application if you want to authenticate the api requests signed with the MAuth protocol.</description>
+    <releaseNotes>No major changes in this version of the WebAPI package this time.</releaseNotes>
     <copyright>$copyright$</copyright>
     <tags>medidata mauth hmac authentication core webapi message handler</tags>
   </metadata>

--- a/tests/Medidata.MAuth.Tests/MAuthAuthenticatorTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthAuthenticatorTests.cs
@@ -15,7 +15,7 @@ namespace Medidata.MAuth.Tests
         public void MAuthAuthenticator_WithInvalidOptions_WillThrowException(string mauthServiceUrl, string privateKey)
         {
             // Assert
-            Assert.Throws<ArgumentNullException>(() => new MAuthAuthenticator(new MAuthOptions()
+            Assert.Throws<ArgumentNullException>(() => new MAuthAuthenticator(new MAuthTestOptions()
             {
                 ApplicationUuid = TestExtensions.ClientUuid,
                 MAuthServiceUrl = mauthServiceUrl != null ? new Uri(mauthServiceUrl) : null,
@@ -26,7 +26,7 @@ namespace Medidata.MAuth.Tests
         [Fact]
         public void MAuthAuthenticator_WithDefaultUuid_WillThrowException()
         {
-            Assert.Throws<ArgumentException>(() => new MAuthAuthenticator(new MAuthOptions()
+            Assert.Throws<ArgumentException>(() => new MAuthAuthenticator(new MAuthTestOptions()
             {
                 ApplicationUuid = default(Guid)
             }));
@@ -69,10 +69,8 @@ namespace Medidata.MAuth.Tests
             var testData = await TestData.For(method);
             var expectedMAuthHeader = $"MWS {TestExtensions.ClientUuid.ToHyphenString()}:{testData.Payload}";
 
-            var authenticator = new MAuthAuthenticator(TestExtensions.ClientOptions(testData.SignedTime));
-
             // Act
-            var actual = await authenticator.SignRequest(testData.Request);
+            var actual = await testData.Request.Sign(TestExtensions.ClientOptions(testData.SignedTime));
 
             // Assert
             Assert.Equal(expectedMAuthHeader, actual.Headers.GetFirstValueOrDefault<string>(Constants.MAuthHeaderKey));

--- a/tests/Medidata.MAuth.Tests/MAuthOwinTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthOwinTests.cs
@@ -1,8 +1,11 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Medidata.MAuth.Core;
 using Medidata.MAuth.Owin;
+using Microsoft.Owin.Hosting;
 using Microsoft.Owin.Testing;
 using Owin;
 using Xunit;
@@ -105,6 +108,47 @@ namespace Medidata.MAuth.Tests
 
                 Assert.Equal("The request has invalid MAuth authentication headers.", ex.Message);
                 Assert.NotNull(ex.InnerException);
+            }
+        }
+
+        [Theory]
+        [InlineData("GET")]
+        [InlineData("DELETE")]
+        [InlineData("POST")]
+        [InlineData("PUT")]
+        public async Task MAuthMiddleware_WithNonSeekableBodyStream_WillRestoreBodyStream(string method)
+        {
+            // Arrange
+            var testData = await TestData.For(method);
+            var canSeek = false;
+            var body = string.Empty;
+
+            using (var server = WebApp.Start("http://localhost:29999", app =>
+            {
+                app.UseMAuthAuthentication(options =>
+                {
+                    options.ApplicationUuid = TestExtensions.ServerUuid;
+                    options.MAuthServiceUrl = TestExtensions.TestUri;
+                    options.PrivateKey = TestExtensions.ServerPrivateKey;
+                    options.MAuthServerHandler = new MAuthServerHandler();
+                });
+
+                app.Run(async context =>
+                {
+                    canSeek = context.Request.Body.CanSeek;
+                    body = await new StreamReader(context.Request.Body).ReadToEndAsync();
+
+                    await context.Response.WriteAsync("Done.");
+                });
+            }))
+            {
+                // Act
+                var response = await new HttpClient().SendAsync(
+                    await testData.Request.Sign(TestExtensions.ClientOptions(testData.SignedTime)));
+
+                // Assert
+                Assert.True(canSeek);
+                Assert.Equal(testData.Content ?? string.Empty, body);
             }
         }
     }

--- a/tests/Medidata.MAuth.Tests/MAuthOwinTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthOwinTests.cs
@@ -35,10 +35,9 @@ namespace Medidata.MAuth.Tests
                 app.Run(async context => await context.Response.WriteAsync("Done."));
             }))
             {
-                var signer = new MAuthAuthenticator(TestExtensions.ClientOptions(testData.SignedTime));
-
                 // Act
-                var response = await server.HttpClient.SendAsync(await signer.SignRequest(testData.Request));
+                var response = await server.HttpClient.SendAsync(
+                    await testData.Request.Sign(TestExtensions.ClientOptions(testData.SignedTime)));
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/tests/Medidata.MAuth.Tests/MAuthTestOptions.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthTestOptions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Medidata.MAuth.Core;
+
+namespace Medidata.MAuth.Tests
+{
+    internal class MAuthTestOptions: MAuthOptionsBase
+    {
+    }
+}

--- a/tests/Medidata.MAuth.Tests/MAuthWebApiTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthWebApiTests.cs
@@ -32,10 +32,9 @@ namespace Medidata.MAuth.Tests
 
             using (var server = new HttpClient(handler))
             {
-                var signer = new MAuthAuthenticator(TestExtensions.ClientOptions(testData.SignedTime));
-
                 // Act
-                var response = await server.SendAsync(await signer.SignRequest(testData.Request));
+                var response = await server.SendAsync(
+                    await testData.Request.Sign(TestExtensions.ClientOptions(testData.SignedTime)));
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/tests/Medidata.MAuth.Tests/Medidata.MAuth.Tests.csproj
+++ b/tests/Medidata.MAuth.Tests/Medidata.MAuth.Tests.csproj
@@ -46,6 +46,10 @@
       <HintPath>..\..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Owin.Hosting, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
       <Private>True</Private>

--- a/tests/Medidata.MAuth.Tests/Medidata.MAuth.Tests.csproj
+++ b/tests/Medidata.MAuth.Tests/Medidata.MAuth.Tests.csproj
@@ -105,6 +105,7 @@
     <Compile Include="MAuthAuthenticatorTests.cs" />
     <Compile Include="MAuthCoreExtensionsTests.cs" />
     <Compile Include="Handlers\MAuthServerHandler.cs" />
+    <Compile Include="MAuthTestOptions.cs" />
     <Compile Include="MAuthWebApiTests.cs" />
     <Compile Include="MAuthOwinTests.cs" />
     <Compile Include="MAuthSigningHandlerTests.cs" />

--- a/tests/Medidata.MAuth.Tests/TestData.cs
+++ b/tests/Medidata.MAuth.Tests/TestData.cs
@@ -19,7 +19,7 @@ namespace Medidata.MAuth.Tests
 
         public long SignedTimeUnixSeconds => SignedTime.ToUnixTimeSeconds();
 
-        public HttpRequestMessage Request => new HttpRequestMessage(Method, "http://localhost")
+        public HttpRequestMessage Request => new HttpRequestMessage(Method, "http://localhost:29999")
         {
             Content = Content != null ? new StringContent(Content) : null
         };

--- a/tests/Medidata.MAuth.Tests/TestExtensions.cs
+++ b/tests/Medidata.MAuth.Tests/TestExtensions.cs
@@ -18,7 +18,7 @@ namespace Medidata.MAuth.Tests
         public static readonly string ServerPrivateKey = GetKeyFromResource(nameof(ServerPrivateKey)).Result;
         public static readonly string ServerPublicKey = GetKeyFromResource(nameof(ServerPublicKey)).Result;
 
-        public static MAuthOptions ServerOptions => new MAuthOptions()
+        public static MAuthOptionsBase ServerOptions => new MAuthTestOptions()
         {
             ApplicationUuid = ServerUuid,
             MAuthServiceUrl = TestUri,
@@ -26,10 +26,9 @@ namespace Medidata.MAuth.Tests
             MAuthServerHandler = new MAuthServerHandler()
         };
 
-        public static MAuthOptions ClientOptions(DateTimeOffset signedTime) => new MAuthOptions()
+        public static MAuthSigningOptions ClientOptions(DateTimeOffset signedTime) => new MAuthSigningOptions()
         {
             ApplicationUuid = ClientUuid,
-            MAuthServiceUrl = TestUri,
             PrivateKey = ClientPrivateKey,
             SignedTime = signedTime
         };

--- a/tests/Medidata.MAuth.Tests/packages.config
+++ b/tests/Medidata.MAuth.Tests/packages.config
@@ -4,6 +4,7 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net452" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Testing" version="3.0.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />


### PR DESCRIPTION
This PR changes the used options instance in MAuthSigningHandler from MAuthOptions to MAuthSigningOptions. This change is necessary in order to not require MAuthServerUrl for the signing (which is not using this url at all).

Additionally this PR contains a fix in the OWIN middleware for the selfhosted request body being non-seekable. In these cases we replace the stream with a MemoryStream to be able to restore the body after reading it for authentication.

@mdsol/team-51 Please review and merge if it OK! Thanks!