### PR TITLE
[MCC-270638] Move NETStandard.Library dependency from root dependencies node to under netstandard1.4

### DIFF
--- a/src/Medidata.MAuth.Core/project.json
+++ b/src/Medidata.MAuth.Core/project.json
@@ -15,7 +15,6 @@
   },
 
   "dependencies": {
-    "NETStandard.Library": "1.6.1",
     "Newtonsoft.Json": "9.0.1"
   },
 
@@ -23,6 +22,7 @@
     "netstandard1.4": {
       "imports": "dnxcore50",
       "dependencies": {
+        "NETStandard.Library": "1.6.1",
         "System.Net.Http": "4.3.0",
         "Portable.BouncyCastle": "1.8.1.2"
       }

--- a/src/Medidata.MAuth.Core/project.json
+++ b/src/Medidata.MAuth.Core/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "2.1.0-*",
+  "version": "2.1.1-*",
   "title": "Medidata.MAuth.Core",
   "authors": [ "Medidata Solutions, Inc." ],
   "description": "A core package for Medidata HMAC protocol implementation. This package contains the core functionality which used by the MAuth authentication protocol-specific components. This package also can be used standalone if you want to sign HTTP/HTTPS requests with Medidata MAuth keys using the .NET HttpClient message handler mechanism.",

--- a/src/Medidata.MAuth.Owin/project.json
+++ b/src/Medidata.MAuth.Owin/project.json
@@ -16,7 +16,9 @@
   },
 
   "dependencies": {
-    "Medidata.MAuth.Core": "2.1.0-*"
+    "Medidata.MAuth.Core": {
+      "target": "project"
+    }
   },
 
   "frameworks": {

--- a/src/Medidata.MAuth.Owin/project.json
+++ b/src/Medidata.MAuth.Owin/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "2.1.0-*",
+  "version": "2.1.1-*",
   "title": "Medidata.MAuth.Owin",
   "description": "This package contains an OWIN middleware to validate signed http requests with the Medidata MAuth protocol. The middleware communicates with an MAuth server in order to confirm the validity of the request authentication header. Include this package in your OWIN-enabled web api if you want to authenticate the api requests signed with the MAuth protocol.",
   "copyright": "Copyright © Medidata Solutions, Inc. 2016",

--- a/src/Medidata.MAuth.WebApi/project.json
+++ b/src/Medidata.MAuth.WebApi/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "2.1.0-*",
+  "version": "2.1.1-*",
   "title": "Medidata.MAuth.WebApi",
   "description": "This package contains an HTTP message handler to validate signed http requests with the Medidata MAuth protocol. The handler communicates with an MAuth server in order to confirm the validity of the request authentication header. Include this package in your WebAPI application if you want to authenticate the api requests signed with the MAuth protocol.",
   "copyright": "Copyright © Medidata Solutions, Inc. 2016",

--- a/src/Medidata.MAuth.WebApi/project.json
+++ b/src/Medidata.MAuth.WebApi/project.json
@@ -16,7 +16,9 @@
   },
 
   "dependencies": {
-    "Medidata.MAuth.Core": "2.1.0-*"
+    "Medidata.MAuth.Core": {
+      "target": "project"
+    }
   },
 
   "frameworks": {

--- a/tests/Medidata.MAuth.Tests/project.json
+++ b/tests/Medidata.MAuth.Tests/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.0-*",
+  "version": "2.1.1-*",
   "title": "Medidata.MAuth.Tests",
   "authors": [ "Medidata Solutions, Inc." ],
   "description": "Assembly which contains unit tests of the Medidata.MAuth framework.",


### PR DESCRIPTION
This to avoid legacy .NET project to download unnecessary NETStandard libraries.

@lschreck-mdsol, @bvillanueva-mdsol, @kenyamat please review and merge if okay.

FYI
@cabbott 