### PR TITLE
[MCC-273076] Fix framework assembly referencing in Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changes in Medidata.MAuth
 
+## v2.1.2
+- **[Medidata.MAuth.Core]** Fixed the .NET Framework assemblies being referenced as dependencies instead of
+framework assemblies causing unnecessary package downloads and referencing from NuGet
+- **[All]** Updated copyright year numbers to the current (2017) year
+- **[All]** Added cache-specific information to the README FAQ section
+
+## v2.1.1
+- **[Medidata.MAuth.Core]** Fixed the NetStandard.Library being a common dependency causing unnecessary package
+downloads and referencing from NuGet
+
 ## v2.1.0
 - Added support for .NET Core with netstandard1.4
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2016 Medidata Solutions Worldwide
+Copyright (c) 2017 Medidata Solutions Worldwide
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ is used as it wraps the original stream in a non-seekable version.
 
 ##### Does Medidata.MAuth support caching?
 
-Yes, we support caching of the responses from the MAuth server in order to not overload it with client information
+Yes, with the **.NET Framework** we support caching of the responses from the MAuth server in order to not overload it with client information
 requests. The caching mechanism in Medidata.MAuth is based on the
 [WebRequestHandler](https://msdn.microsoft.com/en-us/library/system.net.http.webrequesthandler(v=vs.110).aspx)'s
 caching (with the request caching policy set to
@@ -261,4 +261,5 @@ caching (with the request caching policy set to
 utilizes the
 [Windows OS built-in WinINET caching](https://msdn.microsoft.com/en-us/library/windows/desktop/aa383928(v=vs.85).aspx),
 thus it respects all the HTTP-specific cache headers provided by the MAuth server.
+
 

--- a/README.md
+++ b/README.md
@@ -251,3 +251,14 @@ order to authenticate the request we need to read the body, but if the body stre
 restore it for the subsequent middlewares to read. Typical example for this is when the OWIN selfhost infrastructure
 is used as it wraps the original stream in a non-seekable version.
 
+##### Does Medidata.MAuth support caching?
+
+Yes, we support caching of the responses from the MAuth server in order to not overload it with client information
+requests. The caching mechanism in Medidata.MAuth is based on the
+[WebRequestHandler](https://msdn.microsoft.com/en-us/library/system.net.http.webrequesthandler(v=vs.110).aspx)'s
+caching (with the request caching policy set to
+[Default level](https://msdn.microsoft.com/en-us/library/system.net.cache.requestcachelevel(v=vs.110).aspx)), that
+utilizes the
+[Windows OS built-in WinINET caching](https://msdn.microsoft.com/en-us/library/windows/desktop/aa383928(v=vs.85).aspx),
+thus it respects all the HTTP-specific cache headers provided by the MAuth server.
+

--- a/src/Medidata.MAuth.Core/project.json
+++ b/src/Medidata.MAuth.Core/project.json
@@ -1,9 +1,9 @@
 ﻿{
-  "version": "2.1.1-*",
+  "version": "2.1.2-*",
   "title": "Medidata.MAuth.Core",
   "authors": [ "Medidata Solutions, Inc." ],
   "description": "A core package for Medidata HMAC protocol implementation. This package contains the core functionality which used by the MAuth authentication protocol-specific components. This package also can be used standalone if you want to sign HTTP/HTTPS requests with Medidata MAuth keys using the .NET HttpClient message handler mechanism.",
-  "copyright": "Copyright © Medidata Solutions, Inc. 2016",
+  "copyright": "Copyright © Medidata Solutions, Inc. 2017",
   "packOptions": {
     "owners": [ "Medidata Solutions, Inc." ],
     "requireLicenseAcceptance": true,
@@ -29,9 +29,11 @@
     },
     "net452": {
       "dependencies": {
-        "BouncyCastle": "1.8.1",
-        "Microsoft.Net.Http": "2.2.22",
-        "System.Net.Http": "4.0.0"
+        "BouncyCastle": "1.8.1"
+      },
+      "frameworkAssemblies": {
+        "System.Net.Http": "4.0.0.0",
+        "System.Net.Http.WebRequest": "4.0.0.0"
       }
     }
   }

--- a/src/Medidata.MAuth.Owin/project.json
+++ b/src/Medidata.MAuth.Owin/project.json
@@ -2,7 +2,7 @@
   "version": "2.1.1-*",
   "title": "Medidata.MAuth.Owin",
   "description": "This package contains an OWIN middleware to validate signed http requests with the Medidata MAuth protocol. The middleware communicates with an MAuth server in order to confirm the validity of the request authentication header. Include this package in your OWIN-enabled web api if you want to authenticate the api requests signed with the MAuth protocol.",
-  "copyright": "Copyright © Medidata Solutions, Inc. 2016",
+  "copyright": "Copyright © Medidata Solutions, Inc. 2017",
   "authors": [ "Medidata Solutions, Inc." ],
 
   "packOptions": {

--- a/src/Medidata.MAuth.WebApi/project.json
+++ b/src/Medidata.MAuth.WebApi/project.json
@@ -2,7 +2,7 @@
   "version": "2.1.1-*",
   "title": "Medidata.MAuth.WebApi",
   "description": "This package contains an HTTP message handler to validate signed http requests with the Medidata MAuth protocol. The handler communicates with an MAuth server in order to confirm the validity of the request authentication header. Include this package in your WebAPI application if you want to authenticate the api requests signed with the MAuth protocol.",
-  "copyright": "Copyright © Medidata Solutions, Inc. 2016",
+  "copyright": "Copyright © Medidata Solutions, Inc. 2017",
   "authors": [ "Medidata Solutions, Inc." ],
 
   "packOptions": {

--- a/tests/Medidata.MAuth.Tests/project.json
+++ b/tests/Medidata.MAuth.Tests/project.json
@@ -3,7 +3,7 @@
   "title": "Medidata.MAuth.Tests",
   "authors": [ "Medidata Solutions, Inc." ],
   "description": "Assembly which contains unit tests of the Medidata.MAuth framework.",
-  "copyright": "Copyright © Medidata Solutions, Inc. 2016",
+  "copyright": "Copyright © Medidata Solutions, Inc. 2017",
 
   "testRunner": "xunit",
 


### PR DESCRIPTION
This PR changes some of the dependency references of the Core project to being frameworkAssemblies instead of plain dependencies in order to avoid framework-specific packages referenced and downloaded from NuGet.

Also it updates the documents and metadata.

@mdsol/team-51 Please review and merge it if it is 👍. Thanks!