### PR TITLE
[MCC-283382] Remove default HttpClientHandler from constructor

### DIFF
--- a/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
+++ b/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
@@ -21,7 +21,10 @@ namespace Medidata.MAuth.Core
         /// <see cref="MAuthSigningOptions"/>.
         /// </summary>
         /// <param name="options">The options for this message handler.</param>
-        public MAuthSigningHandler(MAuthSigningOptions options): this(options, new HttpClientHandler()) { }
+        public MAuthSigningHandler(MAuthSigningOptions options)
+        {
+            this.options = options;
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MAuthSigningHandler"/> class with the provided
@@ -47,6 +50,9 @@ namespace Medidata.MAuth.Core
         protected async override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            if (InnerHandler == null)
+                InnerHandler = new HttpClientHandler();
+
             return await base
                 .SendAsync(await request.Sign(options), cancellationToken)
                 .ConfigureAwait(continueOnCapturedContext: false);

--- a/src/Medidata.MAuth.WebApi/MAuthAuthenticatingHandler.cs
+++ b/src/Medidata.MAuth.WebApi/MAuthAuthenticatingHandler.cs
@@ -24,7 +24,11 @@ namespace Medidata.MAuth.WebApi
         /// <see cref="MAuthWebApiOptions"/>.
         /// </summary>
         /// <param name="options">The options for this message handler.</param>
-        public MAuthAuthenticatingHandler(MAuthWebApiOptions options) : this(options, new HttpClientHandler()) { }
+        public MAuthAuthenticatingHandler(MAuthWebApiOptions options)
+        {
+            this.options = options;
+            authenticator = new MAuthAuthenticator(options);
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MAuthAuthenticatingHandler"/> class with the provided
@@ -52,6 +56,9 @@ namespace Medidata.MAuth.WebApi
         protected async override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            if (InnerHandler == null)
+                InnerHandler = new HttpClientHandler();
+
             if (!await request.TryAuthenticate(authenticator, options.HideExceptionsAndReturnForbidden))
                 return new HttpResponseMessage(HttpStatusCode.Forbidden) { RequestMessage = request };
 


### PR DESCRIPTION
This PR will remove the default HttpClientHandler instantiation if there is no inner handler provided for the `MAuthSigningHandler` as well as the `MAuthAuthenticatingHandler`.

This change is necessary in order to not cause problems with the HttpClientFactory usage.

@mdsol/team-51 Please review/merge. Thanks!