### PR TITLE
[MCC-310702] Update badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 Medidata.MAuth is a framework that provides support for authenticating web services and applications
 with the Medidata HMAC protocol, MAuth.
 
+## Build Status
+
 | Build | Status |
 | --- | --- |
-| Release | ![Release](https://ci.appveyor.com/api/projects/status/github/mauth-client-dotnet?branch=master&svg=true) |
-| Prerelease | ![Prerelease](https://ci.appveyor.com/api/projects/status/github/mauth-client-dotnet?branch=develop&svg=true) |
+| AppVeyor Release | ![Release](https://ci.appveyor.com/api/projects/status/94450nsec4kwhjpo?branch=master&svg=true) |
+| AppVeyor Prerelease | ![Prerelease](https://ci.appveyor.com/api/projects/status/94450nsec4kwhjpo?branch=develop&svg=true) |
 
 ## What is MAuth?
 


### PR DESCRIPTION
This PR attempts to fix the badge links in the README because for some reason the [Public Repo Way](https://www.appveyor.com/docs/status-badges/#badges-for-projects-with-public-repositories-on-github-and-bitbucket) is not working.

After this merge, we are ready to release 2.3.0.

@mdsol/team-51 Please review/merge. Thanks!