### PR TITLE
[MCC-328941] Fix request body content not rewound after authentication

### DIFF
--- a/src/Medidata.MAuth.AspNetCore/MAuthAspNetCoreExtensions.cs
+++ b/src/Medidata.MAuth.AspNetCore/MAuthAspNetCoreExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Medidata.MAuth.Core;
@@ -18,17 +17,16 @@ namespace Medidata.MAuth.AspNetCore
         /// <returns>The request message.</returns>
         public static HttpRequestMessage ToHttpRequestMessage(this HttpRequest request)
         {
-            var result = new HttpRequestMessage(new HttpMethod(request.Method), request.GetEncodedUrl());
-            result.Content = new StreamContent(request.Body);
+            var result = new HttpRequestMessage(new HttpMethod(request.Method), request.GetEncodedUrl())
+            {
+                Content = new StreamContent(request.Body)
+            };
 
             foreach (var header in request.Headers)
             {
                 if (!result.Headers.TryAddWithoutValidation(header.Key, (IEnumerable<string>)header.Value))
                     result.Content.Headers.TryAddWithoutValidation(header.Key, (IEnumerable<string>)header.Value);
             }
-
-            if (request.Body.CanSeek)
-                request.Body.Seek(0, SeekOrigin.Begin);
 
             return result;
         }

--- a/src/Medidata.MAuth.AspNetCore/MAuthAspNetCoreExtensions.cs
+++ b/src/Medidata.MAuth.AspNetCore/MAuthAspNetCoreExtensions.cs
@@ -28,6 +28,8 @@ namespace Medidata.MAuth.AspNetCore
                     result.Content.Headers.TryAddWithoutValidation(header.Key, (IEnumerable<string>)header.Value);
             }
 
+            request.Body.Rewind();
+
             return result;
         }
 

--- a/src/Medidata.MAuth.AspNetCore/MAuthAspNetCoreExtensions.cs
+++ b/src/Medidata.MAuth.AspNetCore/MAuthAspNetCoreExtensions.cs
@@ -28,8 +28,6 @@ namespace Medidata.MAuth.AspNetCore
                     result.Content.Headers.TryAddWithoutValidation(header.Key, (IEnumerable<string>)header.Value);
             }
 
-            request.Body.Rewind();
-
             return result;
         }
 

--- a/src/Medidata.MAuth.AspNetCore/MAuthMiddleware.cs
+++ b/src/Medidata.MAuth.AspNetCore/MAuthMiddleware.cs
@@ -31,8 +31,7 @@ namespace Medidata.MAuth.AspNetCore
                 return;
             }
 
-            if (context.Request.Body.CanSeek)
-                context.Request.Body.Seek(0, SeekOrigin.Begin);
+            context.Request.Body.Rewind();
 
             await next.Invoke(context);
         }

--- a/src/Medidata.MAuth.AspNetCore/MAuthMiddleware.cs
+++ b/src/Medidata.MAuth.AspNetCore/MAuthMiddleware.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.IO;
+using System.Net;
 using System.Threading.Tasks;
 using Medidata.MAuth.Core;
 using Microsoft.AspNetCore.Http;
@@ -29,6 +30,9 @@ namespace Medidata.MAuth.AspNetCore
                 context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
                 return;
             }
+
+            if (context.Request.Body.CanSeek)
+                context.Request.Body.Seek(0, SeekOrigin.Begin);
 
             await next.Invoke(context);
         }

--- a/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
+++ b/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
@@ -228,6 +228,22 @@ namespace Medidata.MAuth.Core
             }
         }
 
+        /// <summary>
+        /// Sets the stream position to 0 if the stream is seekable; otherwise it will return the stream with its
+        /// current position.
+        /// </summary>
+        /// <param name="stream">The stream to rewind.</param>
+        /// <returns>
+        /// The passed stream with its position set to 0, or the position unchanged if the stream is not seekable.
+        /// </returns>
+        public static Stream Rewind(this Stream stream)
+        {
+            if (stream.CanSeek)
+                stream.Seek(0, SeekOrigin.Begin);
+
+            return stream;
+        }
+
         public static string Dereference(this string keyPathOrKey) =>
             keyPathOrKey.IsValidPath() ? File.ReadAllText(keyPathOrKey) : keyPathOrKey;
 

--- a/src/Medidata.MAuth.Owin/MAuthMiddleware.cs
+++ b/src/Medidata.MAuth.Owin/MAuthMiddleware.cs
@@ -1,8 +1,5 @@
 ﻿using System.IO;
-using System.Linq;
 using System.Net;
-using System.Net.Mime;
-using System.Text;
 using System.Threading.Tasks;
 using Medidata.MAuth.Core;
 using Microsoft.Owin;
@@ -30,6 +27,9 @@ namespace Medidata.MAuth.Owin
                 context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
                 return;
             }
+
+            if (context.Request.Body.CanSeek)
+                context.Request.Body.Seek(0, SeekOrigin.Begin);
 
             await Next.Invoke(context);
         }

--- a/src/Medidata.MAuth.Owin/MAuthMiddleware.cs
+++ b/src/Medidata.MAuth.Owin/MAuthMiddleware.cs
@@ -28,8 +28,7 @@ namespace Medidata.MAuth.Owin
                 return;
             }
 
-            if (context.Request.Body.CanSeek)
-                context.Request.Body.Seek(0, SeekOrigin.Begin);
+            context.Request.Body.Rewind();
 
             await Next.Invoke(context);
         }

--- a/src/Medidata.MAuth.Owin/MAuthOwinExtensions.cs
+++ b/src/Medidata.MAuth.Owin/MAuthOwinExtensions.cs
@@ -27,6 +27,8 @@ namespace Medidata.MAuth.Owin
                     result.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
             }
 
+            request.Body.Rewind();
+
             return result;
         }
 

--- a/src/Medidata.MAuth.Owin/MAuthOwinExtensions.cs
+++ b/src/Medidata.MAuth.Owin/MAuthOwinExtensions.cs
@@ -27,8 +27,6 @@ namespace Medidata.MAuth.Owin
                     result.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
             }
 
-            request.Body.Rewind();
-
             return result;
         }
 
@@ -73,6 +71,8 @@ namespace Medidata.MAuth.Owin
 
             var body = new MemoryStream();
             await context.Request.Body.CopyToAsync(body);
+
+            body.Rewind();
 
             context.Request.Body = body;
         }

--- a/src/Medidata.MAuth.Owin/MAuthOwinExtensions.cs
+++ b/src/Medidata.MAuth.Owin/MAuthOwinExtensions.cs
@@ -16,17 +16,16 @@ namespace Medidata.MAuth.Owin
         /// <returns>The request message.</returns>
         public static HttpRequestMessage ToHttpRequestMessage(this IOwinRequest request)
         {
-            var result = new HttpRequestMessage(new HttpMethod(request.Method), request.Uri);
-            result.Content = new StreamContent(request.Body);
-            
+            var result = new HttpRequestMessage(new HttpMethod(request.Method), request.Uri)
+            {
+                Content = new StreamContent(request.Body)
+            };
+
             foreach (var header in request.Headers)
             {
                 if (!result.Headers.TryAddWithoutValidation(header.Key, header.Value))
                     result.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
             }
-
-            if (request.Body.CanSeek)
-                request.Body.Seek(0, SeekOrigin.Begin);
 
             return result;
         }

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>2.4.0</Version>
+    <Version>2.4.1</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR resolves the issue with the incoming request body stream being not rewound after authentication.

The stream will be rewound at the end of the ASP.NET Core and OWIN middlewares to ensure the next middleware gets the stream rewound down the chain.

@mdsol/team-51 Please review/merge. Thanks!