### PR TITLE
[MCC-347451] Changed the HTTP status code returned on errors from 403 to 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes in Medidata.MAuth
 
+## v3.0.0
+- **[Breaking]** Changed the HTTP status code response in case of any errors (including authentication and validation errors) from Forbidden (403) to Unauthorized (401).  
+`HideExceptionsAndReturnForbidden` property of MAuth option class has also been renamed to `HideExceptionsAndReturnUnauthorized`.
+
 ## v2.4.1
 - **[AspNetCore]** **[Owin]** Fixed an issue with the request body being not rewound in the middlewares before passing
 down the chain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changes in Medidata.MAuth
 
 ## v3.0.0
-- **[Breaking]** Changed the HTTP status code response in case of any errors (including authentication and validation errors) from Forbidden (403) to Unauthorized (401).  
+- **[All]** **Breaking** - Changed the HTTP status code response in case of any errors (including authentication and validation errors) from Forbidden (403) to Unauthorized (401).  
 `HideExceptionsAndReturnForbidden` property of MAuth option class has also been renamed to `HideExceptionsAndReturnUnauthorized`.
 
 ## v2.4.1

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ public class Startup
             options.MAuthServiceUrl = new Uri("https://mauth.imedidata.com");
             options.AuthenticateRequestTimeoutSeconds = 3;
             options.MAuthServiceRetryPolicy = MAuthServiceRetryPolicy.RetryOnce;
-            options.HideExceptionsAndReturnForbidden = true;
+            options.HideExceptionsAndReturnUnauthorized = true;
             options.PrivateKey = "ServerPrivateKey.pem";
             options.Bypass = (request) => request.Uri.AbsolutePath.StartsWith("/allowed");
         });
@@ -174,7 +174,7 @@ public class Startup
             options.MAuthServiceUrl = new Uri("https://mauth.imedidata.com");
             options.AuthenticateRequestTimeoutSeconds = 3;
             options.MAuthServiceRetryPolicy = MAuthServiceRetryPolicy.RetryOnce;
-            options.HideExceptionsAndReturnForbidden = true;
+            options.HideExceptionsAndReturnUnauthorized = true;
             options.PrivateKey = "ServerPrivateKey.pem";
             options.Bypass = (request) => request.Uri.AbsolutePath.StartsWith("/allowed");
         });
@@ -191,17 +191,17 @@ The middlewares take an `MAuthMiddlewareOptions` instance to set up the authenti
 | **PrivateKey** | Determines the RSA private key of the server application for the authentication requests. This key must be in a PEM ASN.1 format. The value of this property can be set as a valid path to a readable key file as well. |
 | **AuthenticateRequestTimeoutSeconds** | An optional parameter that determines the timeout in seconds for the MAuth authentication request - the MAuth component will try to reach the MAuth server for this duration before it throws an exception. If not specified, the default value will be **3 seconds**. |
 | **MAuthServiceRetryPolicy** | The policy for the retry attempts when communicating with the MAuth service. The following policies can be used: `NoRetry` (no retries), `RetryOnce` (one additional attempt), `RetryTwice` (two additional attempts) and `Agressive` (9 additional attempts) - the default value is **RetryOnce**. |
-| **HideExceptionsAndReturnForbidden** | An optional parameter that determines if the middleware should swallow all exceptions and return an empty HTTP response with a status code Forbidden (403) in case of any errors (including authentication and validation errors). The default is **true**. |
+| **HideExceptionsAndReturnUnauthorized** | An optional parameter that determines if the middleware should swallow all exceptions and return an empty HTTP response with a status code Unauthorized (401) in case of any errors (including authentication and validation errors). The default is **true**. |
 | **Bypass** | Determines a function which evaluates if a given request should bypass the MAuth authentication. |
 
-The **HideExceptionsAndReturnForbidden** parameter is useful (if set to **false**) when you have an exception handler
+The **HideExceptionsAndReturnUnauthorized** parameter is useful (if set to **false**) when you have an exception handler
 mechanism (for example a logger) in your middleware pipeline. In this case the MAuth middleware won't swallow the
 exceptions but will throw them with full stack trace and details of the problem - as every authentication errors will
-throw a `Medidata.MAuth.Core.AuthenticationException` you can still return a Forbidden (403) HTTP status code in
+throw a `Medidata.MAuth.Core.AuthenticationException` you can still return a Unauthorized (401) HTTP status code in
 those cases.
 In the other hand, if you don't use any exception handling mechanism, it is recommended to leave this feature disabled
 as setting this to **false** can possibly lead to exposing sensitive details about your application and the
-authentication process. Leaving this parameter as **true** will result the middleware to return a Forbidden (403) HTTP
+authentication process. Leaving this parameter as **true** will result the middleware to return a Unauthorized (401) HTTP
 status code for every error without showing any details.
 
 The **Bypass** function takes a `IOwinRequest` in case of OWIN and an `HttpRequest` instance for ASP.NET Core and
@@ -231,7 +231,7 @@ public static class WebApiConfig
             MAuthServiceUrl = new Uri("https://mauth.imedidata.com"),
             AuthenticateRequestTimeoutSeconds = 3,
             MAuthServiceRetryPolicy = MAuthServiceRetryPolicy.RetryOnce,
-            HideExceptionsAndReturnForbidden = true,
+            HideExceptionsAndReturnUnauthorized = true,
             PrivateKey = "ServerPrivateKey.pem"
         };
 

--- a/src/Medidata.MAuth.AspNetCore/MAuthMiddleware.cs
+++ b/src/Medidata.MAuth.AspNetCore/MAuthMiddleware.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using System.Net;
+﻿using System.Net;
 using System.Threading.Tasks;
 using Medidata.MAuth.Core;
 using Microsoft.AspNetCore.Http;
@@ -25,9 +24,9 @@ namespace Medidata.MAuth.AspNetCore
             context.Request.EnableRewind();
 
             if (!options.Bypass(context.Request) &&
-                !await context.TryAuthenticate(authenticator, options.HideExceptionsAndReturnForbidden))
+                !await context.TryAuthenticate(authenticator, options.HideExceptionsAndReturnUnauthorized))
             {
-                context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
+                context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
                 return;
             }
 

--- a/src/Medidata.MAuth.AspNetCore/MAuthMiddlewareOptions.cs
+++ b/src/Medidata.MAuth.AspNetCore/MAuthMiddlewareOptions.cs
@@ -11,10 +11,10 @@ namespace Medidata.MAuth.AspNetCore
     {
         /// <summary>
         /// Determines if the middleware should swallow all exceptions and return an empty HTTP response with a
-        /// status code Forbidden (403) in case of any errors (including authentication and validation errors).
+        /// status code Unauthorized (401) in case of any errors (including authentication and validation errors).
         /// The default is <see langword="true"/>.
         /// </summary>
-        public bool HideExceptionsAndReturnForbidden { get; set; } = true;
+        public bool HideExceptionsAndReturnUnauthorized { get; set; } = true;
 
         /// <summary>
         /// Determines a function which evaluates if a given request should bypass the MAuth authentication.

--- a/src/Medidata.MAuth.Core/MAuthRequestRetrier.cs
+++ b/src/Medidata.MAuth.Core/MAuthRequestRetrier.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 #if !NETSTANDARD1_4
 using System.Net.Cache;
 #endif

--- a/src/Medidata.MAuth.Owin/MAuthMiddleware.cs
+++ b/src/Medidata.MAuth.Owin/MAuthMiddleware.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using System.Net;
+﻿using System.Net;
 using System.Threading.Tasks;
 using Medidata.MAuth.Core;
 using Microsoft.Owin;
@@ -22,9 +21,9 @@ namespace Medidata.MAuth.Owin
             await context.EnsureRequestBodyStreamSeekable();
 
             if (!options.Bypass(context.Request) &&
-                !await context.TryAuthenticate(authenticator, options.HideExceptionsAndReturnForbidden))
+                !await context.TryAuthenticate(authenticator, options.HideExceptionsAndReturnUnauthorized))
             {
-                context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
+                context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
                 return;
             }
 

--- a/src/Medidata.MAuth.Owin/MAuthMiddlewareOptions.cs
+++ b/src/Medidata.MAuth.Owin/MAuthMiddlewareOptions.cs
@@ -9,12 +9,12 @@ namespace Medidata.MAuth.Owin
     /// </summary>
     public class MAuthMiddlewareOptions: MAuthOptionsBase
     {
-         /// <summary>
+        /// <summary>
         /// Determines if the middleware should swallow all exceptions and return an empty HTTP response with a
-        /// status code Forbidden (403) in case of any errors (including authentication and validation errors).
+        /// status code Unauthorized (401) in case of any errors (including authentication and validation errors).
         /// The default is <see langword="true"/>.
         /// </summary>
-        public bool HideExceptionsAndReturnForbidden { get; set; } = true;
+        public bool HideExceptionsAndReturnUnauthorized { get; set; } = true;
 
         /// <summary>
         /// Determines a function which evaluates if a given request should bypass the MAuth authentication.

--- a/src/Medidata.MAuth.WebApi/MAuthAuthenticatingHandler.cs
+++ b/src/Medidata.MAuth.WebApi/MAuthAuthenticatingHandler.cs
@@ -59,8 +59,8 @@ namespace Medidata.MAuth.WebApi
             if (InnerHandler == null)
                 InnerHandler = new HttpClientHandler();
 
-            if (!await request.TryAuthenticate(authenticator, options.HideExceptionsAndReturnForbidden))
-                return new HttpResponseMessage(HttpStatusCode.Forbidden) { RequestMessage = request };
+            if (!await request.TryAuthenticate(authenticator, options.HideExceptionsAndReturnUnauthorized))
+                return new HttpResponseMessage(HttpStatusCode.Unauthorized) { RequestMessage = request };
 
             return await base
                 .SendAsync(request, cancellationToken)

--- a/src/Medidata.MAuth.WebApi/MAuthWebApiOptions.cs
+++ b/src/Medidata.MAuth.WebApi/MAuthWebApiOptions.cs
@@ -7,11 +7,11 @@ namespace Medidata.MAuth.WebApi
     /// </summary>
     public class MAuthWebApiOptions: MAuthOptionsBase
     {
-         /// <summary>
+        /// <summary>
         /// Determines if the message handler should swallow all exceptions and return an empty HTTP response with a
-        /// status code Forbidden (403) in case of any errors (including authentication and validation errors).
+        /// status code Unauthorized (401) in case of any errors (including authentication and validation errors).
         /// The default is <see langword="true"/>.
         /// </summary>
-        public bool HideExceptionsAndReturnForbidden { get; set; } = true;
+        public bool HideExceptionsAndReturnUnauthorized { get; set; } = true;
     }
 }

--- a/tests/Medidata.MAuth.Tests/Infrastructure/MAuthServerHandler.cs
+++ b/tests/Medidata.MAuth.Tests/Infrastructure/MAuthServerHandler.cs
@@ -29,7 +29,7 @@ namespace Medidata.MAuth.Tests.Infrastructure
                 await request.GetSignature(authInfo),
                 TestExtensions.ServerPublicKey
             ))
-                return new HttpResponseMessage(HttpStatusCode.Forbidden) { RequestMessage = request };
+                return new HttpResponseMessage(HttpStatusCode.Unauthorized) { RequestMessage = request };
 
             if (!request.RequestUri.AbsolutePath.Equals(
                 $"{Constants.MAuthTokenRequestPath}{clientUuid.ToHyphenString()}.json",

--- a/tests/Medidata.MAuth.Tests/MAuthAspNetCoreTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthAspNetCoreTests.cs
@@ -31,7 +31,7 @@ namespace Medidata.MAuth.Tests
                     options.MAuthServiceUrl = TestExtensions.TestUri;
                     options.PrivateKey = TestExtensions.ServerPrivateKey;
                     options.MAuthServerHandler = new MAuthServerHandler();
-                    options.HideExceptionsAndReturnForbidden = false;
+                    options.HideExceptionsAndReturnUnauthorized = false;
                 });
 
                 app.Run(async context => await new StreamWriter(context.Response.Body).WriteAsync("Done."));
@@ -95,7 +95,7 @@ namespace Medidata.MAuth.Tests
                     options.MAuthServiceUrl = TestExtensions.TestUri;
                     options.PrivateKey = TestExtensions.ServerPrivateKey;
                     options.MAuthServerHandler = new MAuthServerHandler();
-                    options.HideExceptionsAndReturnForbidden = false;
+                    options.HideExceptionsAndReturnUnauthorized = false;
                 });
             })))
             {

--- a/tests/Medidata.MAuth.Tests/MAuthAspNetCoreTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthAspNetCoreTests.cs
@@ -73,7 +73,7 @@ namespace Medidata.MAuth.Tests
                 var response = await server.CreateClient().SendAsync(testData.Request);
 
                 // Assert
-                Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+                Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
             }
         }
 

--- a/tests/Medidata.MAuth.Tests/MAuthOwinTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthOwinTests.cs
@@ -73,7 +73,7 @@ namespace Medidata.MAuth.Tests
                 var response = await server.HttpClient.SendAsync(testData.Request);
 
                 // Assert
-                Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+                Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
             }
         }
 
@@ -95,7 +95,7 @@ namespace Medidata.MAuth.Tests
                     options.MAuthServiceUrl = TestExtensions.TestUri;
                     options.PrivateKey = TestExtensions.ServerPrivateKey;
                     options.MAuthServerHandler = new MAuthServerHandler();
-                    options.HideExceptionsAndReturnForbidden = false;
+                    options.HideExceptionsAndReturnUnauthorized = false;
                 });
 
                 app.Run(async context => await context.Response.WriteAsync("Done."));

--- a/tests/Medidata.MAuth.Tests/MAuthWebApiTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthWebApiTests.cs
@@ -66,7 +66,7 @@ namespace Medidata.MAuth.Tests
                 var response = await server.SendAsync(testData.Request);
 
                 // Assert
-                Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+                Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
             }
         }
 
@@ -86,7 +86,7 @@ namespace Medidata.MAuth.Tests
                 MAuthServiceUrl = TestExtensions.TestUri,
                 PrivateKey = TestExtensions.ServerPrivateKey,
                 MAuthServerHandler = new MAuthServerHandler(),
-                HideExceptionsAndReturnForbidden = false
+                HideExceptionsAndReturnUnauthorized = false
             });
 
             using (var server = new HttpClient(handler))

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>2.4.1</Version>
+    <Version>3.0.0</Version>
   </PropertyGroup>
 </Project>

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.0.0-beta1</Version>
   </PropertyGroup>
 </Project>

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>3.0.0-beta1</Version>
+    <Version>3.0.0-pre1</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
@mdsol/team-51 please review and merge.

@jcarres-mdsol I updated the [CHANGELOG](https://github.com/mdsol/mauth-client-dotnet/blob/fix/change-403-to-401/CHANGELOG.md) with major version indicating that this is a breaking change, does this look okay?

Please let me know if I need to notify other teams regarding this change.

FYI: @cabbott 