### PR TITLE
[MCC-365432] Change uuid validation to accept non-v4 uuids

### DIFF
--- a/src/Medidata.MAuth.Core/Constants.cs
+++ b/src/Medidata.MAuth.Core/Constants.cs
@@ -9,7 +9,7 @@ namespace Medidata.MAuth.Core
          
         public static readonly Regex AuthenticationHeaderRegex = new Regex(
             "^MWS " +
-            "(?<uuid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[4][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})" +
+            "(?<uuid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})" +
             ":" +
             "(?<payload>" +
                 "(?:[0-9a-zA-Z+/]{4})*" +

--- a/tests/Medidata.MAuth.Tests/Medidata.MAuth.Tests.csproj
+++ b/tests/Medidata.MAuth.Tests/Medidata.MAuth.Tests.csproj
@@ -61,9 +61,9 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
   </ItemGroup>
 

--- a/tests/Medidata.MAuth.Tests/UtilityExtensionsTest.cs
+++ b/tests/Medidata.MAuth.Tests/UtilityExtensionsTest.cs
@@ -37,6 +37,24 @@ namespace Medidata.MAuth.Tests
         }
 
         [Fact]
+        public async Task TryParseAuthenticationHeader_WithVersion1Uuid_WillSucceed()
+        {
+            // Arrange
+            var uuid = "1ebab21a-4b86-11e1-bcfe-123138140309";
+            var request = await TestData.For("GET");
+
+            var expected = (new Guid(uuid), request.Payload);
+
+            // Act
+            var result = request.MAuthHeader.Replace(TestExtensions.ClientUuid.ToString(), uuid)
+                .TryParseAuthenticationHeader(out var actual);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void ParseAuthenticationHeader_WithInvalidAuthHeader_WillThrowException()
         {
             // Arrange

--- a/tests/Medidata.MAuth.Tests/UtilityExtensionsTest.cs
+++ b/tests/Medidata.MAuth.Tests/UtilityExtensionsTest.cs
@@ -37,24 +37,6 @@ namespace Medidata.MAuth.Tests
         }
 
         [Fact]
-        public async Task TryParseAuthenticationHeader_WithVersion1Uuid_WillSucceed()
-        {
-            // Arrange
-            var uuid = "1ebab21a-4b86-11e1-bcfe-123138140309";
-            var request = await TestData.For("GET");
-
-            var expected = (new Guid(uuid), request.Payload);
-
-            // Act
-            var result = request.MAuthHeader.Replace(TestExtensions.ClientUuid.ToString(), uuid)
-                .TryParseAuthenticationHeader(out var actual);
-
-            // Assert
-            Assert.True(result);
-            Assert.Equal(expected, actual);
-        }
-
-        [Fact]
         public void ParseAuthenticationHeader_WithInvalidAuthHeader_WillThrowException()
         {
             // Arrange

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
As the title says, this PR will remove the restriction on the MAuth uuid validation to be only version 4.

@mdsol/team-51 Please review and merge - then we can release it to the wild! Thanks!