### PR TITLE
[MCC-422186] Fix concurrency issue in MAuthRequestRetrier

### DIFF
--- a/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
+++ b/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
@@ -62,7 +62,7 @@ namespace Medidata.MAuth.Core
 
         private async Task<ApplicationInfo> GetApplicationInfo(Guid applicationUuid) =>
             await (await retrier.GetSuccessfulResponse(applicationUuid, CreateRequest,
-                remainingAttempts: (int)options.MAuthServiceRetryPolicy + 1))
+                requestAttempts: (int)options.MAuthServiceRetryPolicy + 1))
             .Content
             .FromResponse();
 

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>3.0.2</Version>
+    <Version>3.0.3</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The `exception` field in `MAuthRequestRetrier` can be modified from multiple threads, additionally even when an exception would be thrown, the `Request` property would likely be wrong, and the `Responses` contained responses from other failed & successful requests.