### PR TITLE
[MCC-438732] Add Extension Method to Authenticate Requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes in Medidata.MAuth
 
+## v3.1.0
+- **[Core]** Added a new extension method to the utilities which will authenticate a `HttpRequestMessage` with the
+provided options.
+
 ## v3.0.4
 - **[Core]** Fixed an issue with HTTP requests having binary content (the authentication was failing in this case)
 

--- a/src/Medidata.MAuth.Core/UtilityExtensions.cs
+++ b/src/Medidata.MAuth.Core/UtilityExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Medidata.MAuth.Core
 {
@@ -55,5 +57,15 @@ namespace Medidata.MAuth.Core
 
             return true;
         }
+
+        /// <summary>
+        /// Authenticates a <see cref="HttpRequestMessage"/> with the provided options.
+        /// </summary>
+        /// <param name="request">The requesst message to authenticate.</param>
+        /// <param name="options">The MAuth options to use for the authentication.</param>
+        /// <returns>The task for the operation that is when completes will result in <see langword="true"/> if
+        /// the authentication is successful; otherwise <see langword="false"/>.</returns>
+        public static Task<bool> Authenticate(this HttpRequestMessage request, MAuthOptionsBase options) =>
+            new MAuthAuthenticator(options).AuthenticateRequest(request);
     }
 }

--- a/tests/Medidata.MAuth.Tests/UtilityExtensionsTest.cs
+++ b/tests/Medidata.MAuth.Tests/UtilityExtensionsTest.cs
@@ -45,5 +45,30 @@ namespace Medidata.MAuth.Tests
             // Act, Assert
             Assert.Throws<ArgumentException>(() => invalid.ParseAuthenticationHeader());
         }
+
+        [Theory]
+        [InlineData("GET")]
+        [InlineData("DELETE")]
+        [InlineData("POST")]
+        [InlineData("PUT")]
+        public static async Task Authenticate_WithValidRequest_WillAuthenticate(string method)
+        {
+            // Arrange
+            var testData = await method.FromResource();
+
+            var signedRequest = await testData.ToHttpRequestMessage()
+                .AddAuthenticationInfo(new PrivateKeyAuthenticationInfo()
+                {
+                    ApplicationUuid = testData.ApplicationUuid,
+                    PrivateKey = TestExtensions.ClientPrivateKey,
+                    SignedTime = testData.SignedTime
+                });
+
+            // Act
+            var isAuthenticated = await signedRequest.Authenticate(TestExtensions.ServerOptions);
+
+            // Assert
+            Assert.True(isAuthenticated);
+        }
     }
 }

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>3.0.4</Version>
+    <Version>3.1.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR adds a new extension method to authenticate `HttpRequestMessage` instances with a given options.

Currently all the requests coming to MAuth clients/middlewares are authenticated using the internal MAuthAuthenticator. If we want to authenticate a request without a middleware, either MAuthAuthenticator needs to be exposed as a public class (not recommended), or we need a public extension method which will utilize the MAuthAuthenticator but can be used from outside of the client.

@mdsol/team-51 Please review/merge - thanks!