### PR TITLE
[MCC-465787] Add caching for the MAuth server communication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes in Medidata.MAuth
 
+## v3.1.2
+- **[Core]** Fixed and enabled caching of the `ApplicationInfo` from the MAuth server.
+
 ## v3.1.1
 - **[Core]** Added `ConfigureAwait(false)` avoiding any possible deadlocks.
 

--- a/README.md
+++ b/README.md
@@ -303,14 +303,10 @@ is used as it wraps the original stream in a non-seekable version.
 
 ##### Does Medidata.MAuth support caching?
 
-Yes, with the **.NET Framework** we support caching of the responses from the MAuth server in order to not overload it with client information
-requests. The caching mechanism in Medidata.MAuth is based on the
-[WebRequestHandler](https://msdn.microsoft.com/en-us/library/system.net.http.webrequesthandler(v=vs.110).aspx)'s
-caching (with the request caching policy set to
-[Default level](https://msdn.microsoft.com/en-us/library/system.net.cache.requestcachelevel(v=vs.110).aspx)), that
-utilizes the
-[Windows OS built-in WinINET caching](https://msdn.microsoft.com/en-us/library/windows/desktop/aa383928(v=vs.85).aspx),
-thus it respects all the HTTP-specific cache headers provided by the MAuth server.
+Yes, all the **ASP.NET WebApi** handler and the **Owin** and **ASP.NET Core** middlewares support caching of the `ApplicationInfo` from the MAuth server in
+order to not overload it with client information requests (and gradually improve the response times from the middlewares).
+The cache expiration will be set according to the response cache header (max-age) from the MAuth server - or if this
+information not provided, it will be **1 hour** by default for successful requests (i.e. valid application uuids).
 
 ##### The documentation for the `MAuthServiceRetryPolicy.Agressive` retry policy says that it is not recommended for production use. What is the reason for this?
 

--- a/src/Medidata.MAuth.Core/MAuthRequestRetrier.cs
+++ b/src/Medidata.MAuth.Core/MAuthRequestRetrier.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-#if !NETSTANDARD1_4
-using System.Net.Cache;
-#endif
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -18,19 +15,13 @@ namespace Medidata.MAuth.Core
                 ApplicationUuid = options.ApplicationUuid,
                 PrivateKey = options.PrivateKey
             },
-            innerHandler: options.MAuthServerHandler ??
-#if NETSTANDARD1_4
-                new HttpClientHandler()
-#else
-                new WebRequestHandler()
-                {
-                    CachePolicy = new RequestCachePolicy(RequestCacheLevel.Default)
-                }
-#endif
+            innerHandler: options.MAuthServerHandler ?? new HttpClientHandler()
             );
 
-            client = new HttpClient(signingHandler);
-            client.Timeout = TimeSpan.FromSeconds(options.AuthenticateRequestTimeoutSeconds);
+            client = new HttpClient(signingHandler)
+            {
+                Timeout = TimeSpan.FromSeconds(options.AuthenticateRequestTimeoutSeconds)
+            };
         }
 
         public async Task<HttpResponseMessage> GetSuccessfulResponse(Guid applicationUuid,

--- a/src/Medidata.MAuth.Core/Medidata.MAuth.Core.csproj
+++ b/src/Medidata.MAuth.Core/Medidata.MAuth.Core.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>3.1.1</Version>
+    <Version>3.1.2</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR contains the caching mechanism for MAuth authentication that involves requests to the MAuth server.

The solution sets the expiration time based on the MAuth server response cache header (if it is not set, it will be 1 hour by default).

I will update the documentation as well.