### PR TITLE
[MCC-543272] Fix the issue for .netcore 3.0 support 

### DIFF
--- a/src/Medidata.MAuth.AspNetCore/MAuthMiddleware.cs
+++ b/src/Medidata.MAuth.AspNetCore/MAuthMiddleware.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using Medidata.MAuth.Core;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -39,7 +38,7 @@ namespace Medidata.MAuth.AspNetCore
         /// <returns>A <see cref="Task"/> that completes when the middleware has completed processing.</returns>
         public async Task Invoke(HttpContext context)
         {
-            context.Request.EnableRewind();
+            context.Request.EnableBuffering();
 
             if (!options.Bypass(context.Request) &&
                 !await context.TryAuthenticate(authenticator, options.HideExceptionsAndReturnUnauthorized))

--- a/src/Medidata.MAuth.AspNetCore/Medidata.MAuth.AspNetCore.csproj
+++ b/src/Medidata.MAuth.AspNetCore/Medidata.MAuth.AspNetCore.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Medidata.MAuth.Tests/Medidata.MAuth.Tests.csproj
+++ b/tests/Medidata.MAuth.Tests/Medidata.MAuth.Tests.csproj
@@ -69,7 +69,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">


### PR DESCRIPTION
This PR is to fix the issue with .netcore 3.0 support which was reported in this issue:
https://github.com/mdsol/mauth-client-dotnet/issues/48

- Updated `EnableRewind()` to `EnableBuffering()`
- Also updated few other aspnetcore packages

Please review:
@lgabriel-mdsol 
@mdsol/team-51 
@mdsol/architecture-enablement 
@bvillanueva-mdsol 