### PR TITLE
[MCC-555460] Fix deadlocks issues 

### DIFF
--- a/src/Medidata.MAuth.AspNetCore/MAuthAspNetCoreExtensions.cs
+++ b/src/Medidata.MAuth.AspNetCore/MAuthAspNetCoreExtensions.cs
@@ -50,7 +50,8 @@ namespace Medidata.MAuth.AspNetCore
         {
             try
             {
-                return await authenticator.AuthenticateRequest(context.Request.ToHttpRequestMessage());
+                return await authenticator.AuthenticateRequest(context.Request.ToHttpRequestMessage())
+                    .ConfigureAwait(false);
             }
             catch (Exception)
             {

--- a/src/Medidata.MAuth.AspNetCore/MAuthMiddleware.cs
+++ b/src/Medidata.MAuth.AspNetCore/MAuthMiddleware.cs
@@ -41,7 +41,7 @@ namespace Medidata.MAuth.AspNetCore
             context.Request.EnableBuffering();
 
             if (!options.Bypass(context.Request) &&
-                !await context.TryAuthenticate(authenticator, options.HideExceptionsAndReturnUnauthorized))
+                !await context.TryAuthenticate(authenticator, options.HideExceptionsAndReturnUnauthorized).ConfigureAwait(false))
             {
                 context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
                 return;
@@ -49,7 +49,7 @@ namespace Medidata.MAuth.AspNetCore
 
             context.Request.Body.Rewind();
 
-            await next.Invoke(context);
+            await next.Invoke(context).ConfigureAwait(false);
         }
     }
 }

--- a/src/Medidata.MAuth.AspNetCore/Medidata.MAuth.AspNetCore.csproj
+++ b/src/Medidata.MAuth.AspNetCore/Medidata.MAuth.AspNetCore.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />

--- a/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
+++ b/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
@@ -52,10 +52,10 @@ namespace Medidata.MAuth.Core
 
                 var mAuthCore = MAuthCoreFactory.Instantiate(version);
                 var authInfo = GetAuthenticationInfo(request, version);
-                var appInfo = await GetApplicationInfo(authInfo.ApplicationUuid, version);
+                var appInfo = await GetApplicationInfo(authInfo.ApplicationUuid, version).ConfigureAwait(false);
 
-                return mAuthCore.Verify(authInfo.Payload, await mAuthCore.GetSignature(request, authInfo),
-                    appInfo.PublicKey);
+                return mAuthCore.Verify(authInfo.Payload, await mAuthCore.GetSignature(request, authInfo)
+                    .ConfigureAwait(false), appInfo.PublicKey);
             }
             catch (ArgumentException ex)
             {
@@ -97,9 +97,9 @@ namespace Medidata.MAuth.Core
                     applicationUuid,
                     CreateRequest, Constants.MAuthTokenRequestPath,
                     requestAttempts: (int)options.MAuthServiceRetryPolicy + 1
-                );
+                ).ConfigureAwait(false);
 
-                var result = await response.Content.FromResponse();
+                var result = await response.Content.FromResponse().ConfigureAwait(false);
 
                 entry.SetOptions(
                     new MemoryCacheEntryOptions()

--- a/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
+++ b/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
@@ -53,9 +53,9 @@ namespace Medidata.MAuth.Core
                 var mAuthCore = MAuthCoreFactory.Instantiate(version);
                 var authInfo = GetAuthenticationInfo(request, version);
                 var appInfo = await GetApplicationInfo(authInfo.ApplicationUuid, version).ConfigureAwait(false);
+                var signature = await mAuthCore.GetSignature(request, authInfo).ConfigureAwait(false);
 
-                return mAuthCore.Verify(authInfo.Payload, await mAuthCore.GetSignature(request, authInfo)
-                    .ConfigureAwait(false), appInfo.PublicKey);
+                return mAuthCore.Verify(authInfo.Payload, signature, appInfo.PublicKey);
             }
             catch (ArgumentException ex)
             {

--- a/src/Medidata.MAuth.Core/MAuthCoreV2.cs
+++ b/src/Medidata.MAuth.Core/MAuthCoreV2.cs
@@ -16,10 +16,10 @@ namespace Medidata.MAuth.Core
         /// <returns>
         /// A Task object which will result the request signed with the authentication information when it completes.
         /// </returns>
-        public async Task<HttpRequestMessage> Sign(
+        public Task<HttpRequestMessage> Sign(
             HttpRequestMessage request, MAuthSigningOptions options)
         {
-            return await AddAuthenticationInfo(request, new PrivateKeyAuthenticationInfo()
+            return AddAuthenticationInfo(request, new PrivateKeyAuthenticationInfo()
             {
                 ApplicationUuid = options.ApplicationUuid,
                 SignedTime = options.SignedTime ?? DateTimeOffset.UtcNow,

--- a/src/Medidata.MAuth.Core/Medidata.MAuth.Core.csproj
+++ b/src/Medidata.MAuth.Core/Medidata.MAuth.Core.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />

--- a/src/Medidata.MAuth.Core/UtilityExtensions.cs
+++ b/src/Medidata.MAuth.Core/UtilityExtensions.cs
@@ -70,8 +70,8 @@ namespace Medidata.MAuth.Core
         /// <param name="logger">The logger interface used for logging.</param>
         /// <returns>The task for the operation that is when completes will result in <see langword="true"/> if
         /// the authentication is successful; otherwise <see langword="false"/>.</returns>
-        public static Task<bool> Authenticate(this HttpRequestMessage request, MAuthOptionsBase options, ILogger logger) =>
-                new MAuthAuthenticator(options, logger).AuthenticateRequest(request);
+        public static async Task<bool> Authenticate(this HttpRequestMessage request, MAuthOptionsBase options, ILogger logger) =>
+                await new MAuthAuthenticator(options, logger).AuthenticateRequest(request).ConfigureAwait(false);
 
         /// <summary>
         /// Determines the MAuth version enumerator reading authHeader.

--- a/src/Medidata.MAuth.Core/UtilityExtensions.cs
+++ b/src/Medidata.MAuth.Core/UtilityExtensions.cs
@@ -70,8 +70,8 @@ namespace Medidata.MAuth.Core
         /// <param name="logger">The logger interface used for logging.</param>
         /// <returns>The task for the operation that is when completes will result in <see langword="true"/> if
         /// the authentication is successful; otherwise <see langword="false"/>.</returns>
-        public static async Task<bool> Authenticate(this HttpRequestMessage request, MAuthOptionsBase options, ILogger logger) =>
-                await new MAuthAuthenticator(options, logger).AuthenticateRequest(request).ConfigureAwait(false);
+        public static Task<bool> Authenticate(this HttpRequestMessage request, MAuthOptionsBase options, ILogger logger) =>
+                new MAuthAuthenticator(options, logger).AuthenticateRequest(request);
 
         /// <summary>
         /// Determines the MAuth version enumerator reading authHeader.

--- a/src/Medidata.MAuth.Owin/MAuthMiddleware.cs
+++ b/src/Medidata.MAuth.Owin/MAuthMiddleware.cs
@@ -20,9 +20,9 @@ namespace Medidata.MAuth.Owin
 
         public override async Task Invoke(IOwinContext context)
         {
-            await context.EnsureRequestBodyStreamSeekable();
+            await context.EnsureRequestBodyStreamSeekable().ConfigureAwait(false);
             if (!options.Bypass(context.Request) &&
-                !await context.TryAuthenticate(authenticator, options.HideExceptionsAndReturnUnauthorized))
+                !await context.TryAuthenticate(authenticator, options.HideExceptionsAndReturnUnauthorized).ConfigureAwait(false))
             {
                 context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
                 return;
@@ -30,7 +30,7 @@ namespace Medidata.MAuth.Owin
 
             context.Request.Body.Rewind();
 
-            await Next.Invoke(context);
+            await Next.Invoke(context).ConfigureAwait(false);
         }
     }
 }

--- a/src/Medidata.MAuth.Owin/MAuthOwinExtensions.cs
+++ b/src/Medidata.MAuth.Owin/MAuthOwinExtensions.cs
@@ -71,7 +71,7 @@ namespace Medidata.MAuth.Owin
                 return;
 
             var body = new MemoryStream();
-            await context.Request.Body.CopyToAsync(body);
+            await context.Request.Body.CopyToAsync(body).ConfigureAwait(false);
 
             body.Rewind();
 

--- a/src/Medidata.MAuth.Owin/MAuthOwinExtensions.cs
+++ b/src/Medidata.MAuth.Owin/MAuthOwinExtensions.cs
@@ -47,7 +47,8 @@ namespace Medidata.MAuth.Owin
         {
             try
             {
-                return await authenticator.AuthenticateRequest(context.Request.ToHttpRequestMessage());
+                return await authenticator.AuthenticateRequest(context.Request.ToHttpRequestMessage()).
+                  ConfigureAwait(false);
             }
             catch (Exception)
             {

--- a/src/Medidata.MAuth.Owin/Medidata.MAuth.Owin.csproj
+++ b/src/Medidata.MAuth.Owin/Medidata.MAuth.Owin.csproj
@@ -10,6 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Medidata.MAuth.Core\Medidata.MAuth.Core.csproj" />
   </ItemGroup>
 

--- a/src/Medidata.MAuth.WebApi/MAuthAuthenticatingHandler.cs
+++ b/src/Medidata.MAuth.WebApi/MAuthAuthenticatingHandler.cs
@@ -60,7 +60,7 @@ namespace Medidata.MAuth.WebApi
             if (InnerHandler == null)
                 InnerHandler = new HttpClientHandler();
 
-            if (!await request.TryAuthenticate(authenticator, options.HideExceptionsAndReturnUnauthorized))
+            if (!await request.TryAuthenticate(authenticator, options.HideExceptionsAndReturnUnauthorized).ConfigureAwait(false))
                 return new HttpResponseMessage(HttpStatusCode.Unauthorized) { RequestMessage = request };
 
             return await base

--- a/src/Medidata.MAuth.WebApi/MAuthWebApiExtensions.cs
+++ b/src/Medidata.MAuth.WebApi/MAuthWebApiExtensions.cs
@@ -24,7 +24,7 @@ namespace Medidata.MAuth.WebApi
         {
             try
             {
-                return await authenticator.AuthenticateRequest(request);
+                return await authenticator.AuthenticateRequest(request).ConfigureAwait(false);
             }
             catch (Exception)
             {

--- a/src/Medidata.MAuth.WebApi/Medidata.MAuth.WebApi.csproj
+++ b/src/Medidata.MAuth.WebApi/Medidata.MAuth.WebApi.csproj
@@ -10,6 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="4.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Medidata.MAuth.Core\Medidata.MAuth.Core.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Recently, there had been some problem of  deadlocks on Authentication path. Therefore, this PR adds `ConfigureAwait(false)` on all of the possible cases of Authentication path to resolve those issues.
Also added `ConfigureAwaitCheck.Analyzer` to find out `await` without `ConfigureAwait(false)`

Please review:
@danielloganking 
@mdsol/team-51 
@mdsol/architecture-enablement 
