### PR TITLE
[MCC-555926] Fixed handling of MWSV2 header throwing 403 error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v4.0.1
 - **[Core]** Fixed default sigining with both MWS and MWSV2 instead of option selected by consuming application.
 - **[Core]** Fixed an issue related to token request path which is same for both MWS and MWSV2 protocol.
+- **[Core]** Fixed a bug related to signing with MWSV2 protocol which was due to error in signature.
 
 ## v4.0.0
 - **[All]** Added implementation for MWSV2 signinig and authentication. Added logging support during MAuthentication.

--- a/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
+++ b/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
@@ -95,7 +95,7 @@ namespace Medidata.MAuth.Core
                 var retrier = new MAuthRequestRetrier(options, version);
                 var response = await retrier.GetSuccessfulResponse(
                     applicationUuid,
-                    CreateRequest, Constants.MAuthTokenRequestPath,
+                    CreateRequest,
                     requestAttempts: (int)options.MAuthServiceRetryPolicy + 1
                 ).ConfigureAwait(false);
 
@@ -109,9 +109,9 @@ namespace Medidata.MAuth.Core
                 return result;
             });
 
-        private HttpRequestMessage CreateRequest(Guid applicationUuid, string tokenRequestPath) =>
+        private HttpRequestMessage CreateRequest(Guid applicationUuid) =>
             new HttpRequestMessage(HttpMethod.Get, new Uri(options.MAuthServiceUrl,
-                $"{tokenRequestPath}{applicationUuid.ToHyphenString()}.json"));
+                $"{Constants.MAuthTokenRequestPath}{applicationUuid.ToHyphenString()}.json"));
 
         /// <summary>
         /// Extracts the authentication information from a <see cref="HttpRequestMessage"/>.

--- a/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
+++ b/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
@@ -196,14 +196,5 @@ namespace Medidata.MAuth.Core
             });
             return string.Join("&", encodedQueryStrings);
         }
-
-        /// <summary>
-        /// Provides an SHA512 hash value of bytes.
-        /// </summary>
-        /// <param name="value">The byte value for calculating the hash.</param>
-        /// <returns>SHA512 hash of the input value.</returns>
-        public static byte[] AsSha512HashV2(this byte[] value) =>
-            SHA512.Create().ComputeHash(value);
-
     }
 }

--- a/src/Medidata.MAuth.Core/MAuthCoreV2.cs
+++ b/src/Medidata.MAuth.Core/MAuthCoreV2.cs
@@ -43,7 +43,7 @@ namespace Medidata.MAuth.Core
             var rsa = new RSACryptoServiceProvider();
             rsa.PersistKeyInCsp = false;
             rsa.ImportParameters(publicKey.AsRsaParameters());
-            return rsa.VerifyHash(signature, CryptoConfig.MapNameToOID("SHA512"), signedData);
+            return rsa.VerifyData(signature, CryptoConfig.MapNameToOID("SHA512"), signedData);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Medidata.MAuth.Core
         /// <param name="authInfo">
         /// The <see cref="AuthenticationInfo"/> which holds the application uuid and the time of the signature.
         /// </param>
-        /// <returns>A Task object which will result the SHA512 hash of the signature when it completes.</returns>
+        /// <returns>A Task object which will result the byte value of signature when it completes.</returns>
         public async Task<byte[]> GetSignature(HttpRequestMessage request, AuthenticationInfo authInfo)
         {
             var encodedHttpVerb = request.Method.Method.ToBytes();
@@ -64,7 +64,7 @@ namespace Medidata.MAuth.Core
 
             var requestBody = request.Content != null ?
                 await request.Content.ReadAsByteArrayAsync().ConfigureAwait(false) : new byte[] { };
-            var requestBodyDigest = requestBody.AsSha512HashV2();
+            var requestBodyDigest = requestBody.AsSHA512Hash();
 
             var encodedCurrentSecondsSinceEpoch = authInfo.SignedTime.ToUnixTimeSeconds().ToString().ToBytes();
             var encodedQueryParams = !string.IsNullOrEmpty(request.RequestUri.Query) ?
@@ -78,7 +78,7 @@ namespace Medidata.MAuth.Core
                 encodedAppUUid, Constants.NewLine,
                 encodedCurrentSecondsSinceEpoch, Constants.NewLine,
                 encodedQueryParams
-            }.Concat().AsSha512HashV2();
+            }.Concat();
         }
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace Medidata.MAuth.Core
             signer.PersistKeyInCsp = false;
             signer.ImportParameters(authInfo.PrivateKey.AsRsaParameters());
 
-            return Convert.ToBase64String(signer.SignHash(unsignedData, CryptoConfig.MapNameToOID("SHA512")));
+            return Convert.ToBase64String(signer.SignData(unsignedData, CryptoConfig.MapNameToOID("SHA512")));
         }
 
         /// <summary>

--- a/src/Medidata.MAuth.Core/MAuthRequestRetrier.cs
+++ b/src/Medidata.MAuth.Core/MAuthRequestRetrier.cs
@@ -26,7 +26,7 @@ namespace Medidata.MAuth.Core
         }
 
         public async Task<HttpResponseMessage> GetSuccessfulResponse(Guid applicationUuid,
-            Func<Guid,string, HttpRequestMessage> requestFactory, string tokenRequestPath, int requestAttempts)
+            Func<Guid, HttpRequestMessage> requestFactory, int requestAttempts)
         {
             if (requestFactory == null)
                 throw new ArgumentNullException(nameof(requestFactory));
@@ -43,7 +43,7 @@ namespace Medidata.MAuth.Core
             int remainingAttempts = requestAttempts;
             while (remainingAttempts > 0)
             {
-                var request = requestFactory?.Invoke(applicationUuid, tokenRequestPath);
+                var request = requestFactory?.Invoke(applicationUuid);
 
                 if (request == null)
                     throw new ArgumentException(

--- a/tests/Medidata.MAuth.Tests/MAuthCoreV2Tests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthCoreV2Tests.cs
@@ -62,13 +62,13 @@ namespace Medidata.MAuth.Tests
         {
             // Arrange
             var signature = "This is a signature.";
-            var unsignedData = signature.ToBytes().AsSha512HashV2();
+            var unsignedData = signature.ToBytes();
             var mAuthCore = new MAuthCoreV2();
 
             var signer = new RSACryptoServiceProvider();
             signer.PersistKeyInCsp = false;
             signer.ImportParameters(TestExtensions.ClientPrivateKey.AsRsaParameters());
-            var signedData = signer.SignHash(unsignedData, CryptoConfig.MapNameToOID("SHA512"));
+            var signedData = signer.SignData(unsignedData, CryptoConfig.MapNameToOID("SHA512"));
 
             // Act
             var result = mAuthCore.Verify(signedData, unsignedData, TestExtensions.ClientPublicKey);
@@ -98,11 +98,11 @@ namespace Medidata.MAuth.Tests
             {
                 testData.Method.ToBytes(), Constants.NewLine,
                 testData.Url.AbsolutePath.ToBytes(), Constants.NewLine,
-                content.AsSha512HashV2(), Constants.NewLine,
+                content.AsSHA512Hash(), Constants.NewLine,
                 testData.ApplicationUuidString.ToBytes(), Constants.NewLine,
                 testData.SignedTimeUnixSeconds.ToString().ToBytes(), Constants.NewLine,
                 queryParams
-            }.Concat().AsSha512HashV2();
+            }.Concat();
 
             var authInfo = new PrivateKeyAuthenticationInfo()
             {

--- a/tests/Medidata.MAuth.Tests/Mocks/RequestDataV2/DELETE.json
+++ b/tests/Medidata.MAuth.Tests/Mocks/RequestDataV2/DELETE.json
@@ -1,7 +1,7 @@
 {
-  "Url": "http://localhost:29999/test?one=hello&two=how",
-  "Method": "DELETE",
-  "ApplicationUuid": "192cce84-8466-490e-b03e-074f82da3ee2",
-  "SignedTime": "2016-08-01 05:40:38 +0000",
-  "Payload": "JaFjw0SCWI+y6dLbhSYOBgjmCFZ5nR8hTEK5GZqMjlAnif3J/lAYdbMVPaGkC5qNBKOOwqh2D4CFyOejVrbZ5uGS5q3MteI7pO4jPM3ZbWz2yaa1rc2ZlhKcm42Y1YpgChKwHoN/NuZHogyunv1KlYR8CDOt8k+uIF0G0TNVOEv3Puh3NqM+HbuNhWupZBmsGH7u/mo2yXi1Z5FD9YfeyG5eWFtwQ7Ui5SSTmgF7hlgtqoM5EYCRzp9wy1xZrB+MpsfMsSFTS5aa6Rydbj3bTHHH9AS8fjRtWHAEe/W5OOfQWfc+O70u46AsINhJbA1Sw4mqrTvEuGkkEr3oYyzsrQ=="
+    "Url": "http://localhost:29999/test?one=hello&two=how",
+    "Method": "DELETE",
+    "ApplicationUuid": "192cce84-8466-490e-b03e-074f82da3ee2",
+    "SignedTime": "2016-08-01 05:40:38 +0000",
+    "Payload": "kqKpzbZrL/1b6tZ1aSo9ZonS/fWli6kCaMcfkR0HI6TRJxXnhW8TYote5v0yREik9Pd389kuA+cOlxWfrng5Pf09GK9AbBR6S/XXkTXA4qqEaNru00myUlOV1U+JXSeqrJXpFY44sLJT6p+ALo8HenzyVanXNO4Zci0P8ZA5f/56TZIoI7Di9PAr5gUelslyzWUPd4bgTztFGISKNVidHAflbi0g+0qqtxasMIfSy/PBrthhScxPEp7LELa1RXuwjs2nukNBN8rZAnSR/r6GgfxjA1Cgh6Yil7E0SVdQHDPR0wlm2l17+PT31bPX/Whl4upeAC2uHLauZAnz+AShhw=="
 }

--- a/tests/Medidata.MAuth.Tests/Mocks/RequestDataV2/GET.json
+++ b/tests/Medidata.MAuth.Tests/Mocks/RequestDataV2/GET.json
@@ -1,7 +1,7 @@
 {
-  "Url": "http://localhost:29999/test?one=hello&two=how",
-  "Method": "GET",
-  "ApplicationUuid": "192cce84-8466-490e-b03e-074f82da3ee2",
-  "SignedTime": "2016-08-01 03:22:47 +0000",
-  "Payload": "Vb3BqsWQPBRvh9QLAWpsJAnuzHd6+hwdjqpgB/tRgEfiWWeIFjzRsNvUPqPyx03adNLiZWwBWK/+7Axo78u18QgO/Sxn7wVh/2U6+MM2fJwADAj07zI461ulfSUihy6qHPumEI9ylX9hMMs4pxPRTmE4fTYI7kJ3KDPBThBHnsL9gOor49P5QyndxwKuH+pxG/+wqqjgtCfHFMOoJbvitNhgiUD9XVyc9r/qQH0hPnPylDVOOhAXzzgN9fZT75H3K6bQffiBEfmqcwEKhzM32d3pb956pmsOHHtoJ1SsbJfE+aWOuI/NQUbIuLHfCZbhjDYamvjj90a/tIUnO9kz5w=="
+    "Url": "http://localhost:29999/test?one=hello&two=how",
+    "Method": "GET",
+    "ApplicationUuid": "192cce84-8466-490e-b03e-074f82da3ee2",
+    "SignedTime": "2016-08-01 03:22:47 +0000",
+    "Payload": "HtUETyg9mA7NAkVRb4l1DFA+at+DIL0GvVM+4tmZUSdhvj+94fHVDCf6xtpA1KorZPbaNhGxfoRAYYMRYO5TvMqYfTi1y+7sQzA70DFAAebSOAcLNEnIoPIQkocruBEM4Kbg0/mYe9F0OwwMcMqThvR0cp1aKZBcTe1stds/srasXgLMoS74CxtNQIkyPPLEktWvd1ffTZLVTTZDrPCykugIVgDEpMe02a+1c3w+OwCDUwy2FKpF9NpWdZ6TH2CXTd9W0jcrApiA1UpoNz8vZwgylVKceGRR5nmMKAh5A9E5iQwiCEj002jntfWs2epz87z37FS5OjZuoenStC4aFw=="
 }

--- a/tests/Medidata.MAuth.Tests/Mocks/RequestDataV2/POST.json
+++ b/tests/Medidata.MAuth.Tests/Mocks/RequestDataV2/POST.json
@@ -1,8 +1,8 @@
 {
-  "Url": "http://localhost:29999/test?one=hello&two=how",
-  "Method": "POST",
-  "ApplicationUuid": "192cce84-8466-490e-b03e-074f82da3ee2",
-  "SignedTime": "2016-08-01 03:31:54 +0000",
-  "Base64Content": "VGhlIHJlcXVlc3QgYm9keSBmb3IgdGhlIFBPU1QgbWVzc2FnZS4=",
-  "Payload": "MDc38+RSrknfBon3zf2RWIn0m3B0qLpf7bBGHPAtUU4/31KYpsRDSzxLefVlReffe7vMndOV8gEsXDNzglOu9bVU4KSK1Wz2kvjlW9Mij+fSps8DUkM+xiljjFFnFUQMH2xVq3tlo1XyvGIPFlbkCcLcEG6o+UTUPTkjIpmFJx1M4+LgQPILey6L0nFBXT7vviZ+zkGjyfH7FTrSjmrOANCbjzKb5fKckP/+IZjFql6J3UJXK7J90P5tb2oag6LXQgkWTzIDgQO/0Xg0NOOz3Zbj5IX9vHF9p3ekITeVt3BuLs3zqdRiSsl17173p51ERRHwhtqeue38BYJlznZmLg=="
+    "Url": "http://localhost:29999/test?one=hello&two=how",
+    "Method": "POST",
+    "ApplicationUuid": "192cce84-8466-490e-b03e-074f82da3ee2",
+    "SignedTime": "2016-08-01 03:31:54 +0000",
+    "Base64Content": "VGhlIHJlcXVlc3QgYm9keSBmb3IgdGhlIFBPU1QgbWVzc2FnZS4=",
+    "Payload": "JqAFdCf3l30dGGtUmY2M27XIRc5JSnSZQwJl/ph2LSLAczzYA/vLTdJtd5BY+E9C3u+jnBhJC7Wfno2gUWU8GsDAEr5qu3qIsg4fAc7jlvFGv9C3EOtyulCouGCFPfg63NQihI2ZBV9qkoeXea1RG9xNw8YhvlmOKJW6Qd+WKjR58iwhb441qmjeBRT0av9NTWxRqz4eBxYiMuOSfvDj7RUGotV5SSTOkYUbmxXMjNZK2kp9n2Z2kxUvTeted09qL/8mmS/301gTCkJhU9ykOcRTfPqMey10P7hjQoxrMbSuW6XgZW2R5vHDEHeuNvjKVLeS/xuy85b9PUVj1cCS7g=="
 }

--- a/tests/Medidata.MAuth.Tests/Mocks/RequestDataV2/POSTWithBinaryData.json
+++ b/tests/Medidata.MAuth.Tests/Mocks/RequestDataV2/POSTWithBinaryData.json
@@ -1,8 +1,8 @@
 {
-  "Url": "http://localhost:29999/test?one=hello&two=how",
-  "Method": "POST",
-  "ApplicationUuid": "192cce84-8466-490e-b03e-074f82da3ee2",
-  "SignedTime": "2018-10-02 08:21:03 +0000",
-  "Base64Content": "N3q8ryccAAPP2NhAnAoAAAAAAABUAAAAAAAAAJp51s8AJhvKRmda8ne4fYbYQdsFNc2DpXwSpQXbkL0vFNNxcpaoin2EVnGNaiKYq549w1XvzKXD3XbQa2rmXszZWApBl1bI/FsLDKGC0VHA+Y6actTa9q0WzOvPT7/aMG+3/N3IbuV6O9dsvLNbWeoADUnubbql0yh6JA15cgda8pWI/9o6LnMsEPHBctImUxDUvnAdxMll37Vx9jnjKVTZ3FUqN6kJ6LpZgYlX3pFsgT8ABjgdhg4dIE7xwUdom4LWsylukG/JYGNuCi58JLtx5H8I1mUgnjpXDSL1Z6xRSpypddIQjv+3MpHD5iQlYTkhfwmczvSQZG+aSkOk6A5BL67QV4ozo03RH2nP3QqTQnwEWhmyvWV5AQGWukryjLbhilhIaN7oqS/B9Jhve666xIhfg8Ev7F+lrHgvtue1cnbaCVFXuyZJs0jYfRds4wy6Ytkh8dE=",
-  "Payload": "Kcw87FCuY3D16X+mvUHlt1eVENLH/zs4OIfkikV6y/47DTH6aV1nzv1kl1CUHP0tE279bSSMupQUQvfPLH/cJ+2igf64HfdOSIUTJwEr+6O68oINTiiNAVc2VeO41SYXqn9857usLIem75j9egpHBYqkcKN4D+WsxxWBEf/ee73vHVJYvPiK63FTjw4P+Ek31ccn0MexxRUP/eYuo5ahE6UgooWZjIgseB3jRWPZ9LwI/zyb2HDRVebk+uGX0HFmnZAHQ4ut6Fft6AJRTMl+kNtUL6MEdI6ofPQj7uLjpNcz6sXAx/tmzs5z/kWyatfBCMBku/RE1yUoYm051NgF7g=="
+    "Url": "http://localhost:29999/test?one=hello&two=how",
+    "Method": "POST",
+    "ApplicationUuid": "192cce84-8466-490e-b03e-074f82da3ee2",
+    "SignedTime": "2018-10-02 08:21:03 +0000",
+    "Base64Content": "N3q8ryccAAPP2NhAnAoAAAAAAABUAAAAAAAAAJp51s8AJhvKRmda8ne4fYbYQdsFNc2DpXwSpQXbkL0vFNNxcpaoin2EVnGNaiKYq549w1XvzKXD3XbQa2rmXszZWApBl1bI/FsLDKGC0VHA+Y6actTa9q0WzOvPT7/aMG+3/N3IbuV6O9dsvLNbWeoADUnubbql0yh6JA15cgda8pWI/9o6LnMsEPHBctImUxDUvnAdxMll37Vx9jnjKVTZ3FUqN6kJ6LpZgYlX3pFsgT8ABjgdhg4dIE7xwUdom4LWsylukG/JYGNuCi58JLtx5H8I1mUgnjpXDSL1Z6xRSpypddIQjv+3MpHD5iQlYTkhfwmczvSQZG+aSkOk6A5BL67QV4ozo03RH2nP3QqTQnwEWhmyvWV5AQGWukryjLbhilhIaN7oqS/B9Jhve666xIhfg8Ev7F+lrHgvtue1cnbaCVFXuyZJs0jYfRds4wy6Ytkh8dE=",
+    "Payload": "eRbMUT9j1rrMFs2TT8mF5agDET+6Y4jhyuS6zxlVgZ73S5SV65EZEqPKOuG4ubDeRN/sH2SgAQ0oMtAZJVzwj0BrDegrQOCC0TOHDb47xLoLnCHcgg/cweFL9QU5etBcKCmpgz/obHTg/kIbkuX3haHj7L9nOKKEO02txekTi5aqrfri0aohh5KD7JTKjwhPZDfbhHMPKLo7KI/sabZuJyQSrreOBsmU0BA5rIzezHu0RK5A8FYEnLZMxlFG/yTa/KitCoA0Pi19oesvTAa3fp6GNJKygkPtNBmmxbvBKzZWXMWLrmojf0RkjXwt/0owRaB2UGYHSQGeRhqaTx8tAg=="
 }

--- a/tests/Medidata.MAuth.Tests/Mocks/RequestDataV2/PUT.json
+++ b/tests/Medidata.MAuth.Tests/Mocks/RequestDataV2/PUT.json
@@ -1,8 +1,8 @@
 {
-  "Url": "http://localhost:29999/test?one=hello&two=how",
-  "Method": "PUT",
-  "ApplicationUuid": "192cce84-8466-490e-b03e-074f82da3ee2",
-  "SignedTime": "2016-08-01 05:38:19 +0000",
-  "Base64Content": "VGhlIHJlcXVlc3QgYm9keSBmb3IgdGhlIFBVVCBtZXNzYWdlLg==",
-  "Payload": "m9BjozK5VVEkTwb6ectmSC4MVvi02FPbE+d8mem8nYDz/1rpPUqwvmQvZDPBGOVduVAmwuZnXmmRHJfUwF0SwMPilivEmp1Mc4VbkH/DGvVLq/5Jy4GuQYk/rtSkPsp3Ee2TbhSwYtfSfF6ACUsLSkIqCDjJaL7K4fgV7B+Xl7hFefm9gY1r3xLIMX/aX+2KS4r0J7uCFRGjubi53JYC1+XkMoUqkNJXQ1Cpuw+5EkIZCVja+Crz31YuTSBlYDF76LofXPvlKpF+oh6B+/UHb8pbuSSJGjmTgbhluzoJbVJ0SPYxkXoscrtMfgdvkQYgE5jaMo521A6Oi97wgnRWSg=="
+    "Url": "http://localhost:29999/test?one=hello&two=how",
+    "Method": "PUT",
+    "ApplicationUuid": "192cce84-8466-490e-b03e-074f82da3ee2",
+    "SignedTime": "2016-08-01 05:38:19 +0000",
+    "Base64Content": "VGhlIHJlcXVlc3QgYm9keSBmb3IgdGhlIFBVVCBtZXNzYWdlLg==",
+    "Payload": "iiKC8rzSiAWDqniB7gQovk5HB7foq7tiQExLO8/O+N7K2BPPrj+xtk06m+Q5lSluCWxLFSQk7NK0EPqzQpeUtOH4sm+9eUL8P3MsPc4WXw58wjJ0S6ZmsFkCrS8kLWVji65/Z2jA90EHlrPkmu9MvFURmeFy6st+hHEGnS3drh2WBWI5yGMmMUiwOD6yPonZ86ydMNN03i60tOreOogKYOhk4BDazRM3304Nwp0pSjIEPsprYzZh/NOIFxNh+Iu+uaQnCx0R6ZZmHUAcSbb4p07EM+TqhhiZKOglCRYREUzXTX3xOLYt16/fsqWen2ZX7VfBpPBDfyft0P/zzGE3ug=="
 }


### PR DESCRIPTION
Recently, a bug was reported by @lgabriel-mdsol that when latest "mauth-client-dotnet" was used for Authentication, it is throwing forbidden `403` error.

**Scenario** : By default, sign on is with both `MWS` and `MWSV2` protocol. Therefore, during authentication, it checks for `MWSV2` protocol first and if it finds the header, it tries to verify `MWSV2` header.

**Problem**
During the process of verification, it has to fetch `publickey` from mauth. The mauth url is same for both protocol i.e. `<mauth_url>/mauth/v1/security_tokens/<*.json>`. And, during the fetching process, it includes both `MWS` and `MWSV2` protocol. And, this process was throwing `403` i.e. forbidden error.

**Investigation**
During this process thanks to @lgabriel-mdsol (initially) and later @cmcinnes-mdsol , we uncovered that the issue was due to when `MWSV2` header is added in the fetching process. Then, we slowly uncovered there is something wrong in the signature.

**Fix**
After finding out the fault in signature,  when we made a fix in the signature; we are successfully able to retrieve `publickey` without any error and able to verify when both `MWS` and `MWSV2` headers are added.
This PR includes the fix:

- Body digest after `SHA512` hashed needs to be converted into proper format `Hex.Encode(...)`.
- Updated `SignHash` to use `SignData` which does the hashing of the unsigned signature too. 
- Similarly, updated `VerifyHash` to use `VerifyData`.
- Updated unit tests and updated changelog for the fix input.
- Also removed unnecessary code from `MAuthAuthenticator.cs` and `MAuthRequestRetrier.cs`

Please review and merge:
@mdsol/architecture-enablement 
@mdsol/team-51 
@lgabriel-mdsol 
@cabbott 
@cmcinnes-mdsol 

