### PR TITLE
[Fix] Update aspnetcore version to 2.1 LTS 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes in Medidata.MAuth
 
+## v4.0.2
+- **[AspNetCore]** Update aspnetcore version to aspnetcore2.1 LTS.
+
 ## v4.0.1
 - **[Core]** Fixed default sigining with both MWS and MWSV2 instead of option selected by consuming application.
 - **[Core]** Fixed an issue related to token request path which is same for both MWS and MWSV2 protocol.

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ in your project in order to make Medidata.MAuth work for you.
 ##### Is there an .NET Standard/Core support?
 
 Yes, for signing outgoing requests you can use the library with any framework which implements
-the **.NET Standard 2.0** and onwards; additionally we support the **ASP.NET Core App 2.0** and onwards with a middleware
+the **.NET Standard 2.0** and onwards; additionally we support the **ASP.NET Core App 2.1** and onwards with a middleware
 for authenticating the incoming requests.
 
 ##### What Cryptographic provider is used for the encryption/decryption?

--- a/src/Medidata.MAuth.AspNetCore/Medidata.MAuth.AspNetCore.csproj
+++ b/src/Medidata.MAuth.AspNetCore/Medidata.MAuth.AspNetCore.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <Description>This package contains an ASP.NET Core middleware to validate signed http requests with the Medidata MAuth protocol. The middleware communicates with an MAuth server in order to confirm the validity of the request authentication header. Include this package in your ASP.NET Core web api if you want to authenticate the api requests signed with the MAuth protocol.</Description>
     <AssemblyTitle>Medidata.MAuth.AspNetCore</AssemblyTitle>
     <AssemblyName>Medidata.MAuth.AspNetCore</AssemblyName>
@@ -14,9 +14,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Medidata.MAuth.Tests/Medidata.MAuth.Tests.csproj
+++ b/tests/Medidata.MAuth.Tests/Medidata.MAuth.Tests.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright © Medidata Solutions, Inc. 2017</Copyright>
     <AssemblyTitle>Medidata.MAuth.Tests</AssemblyTitle>
     <Authors>Medidata Solutions, Inc.</Authors>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
     <AssemblyName>Medidata.MAuth.Tests</AssemblyName>
     <PackageId>Medidata.MAuth.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -60,16 +60,16 @@
     <Compile Remove="MAuthAspNetCoreTests.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <ProjectReference Include="..\..\src\Medidata.MAuth.AspNetCore\Medidata.MAuth.AspNetCore.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.1" />
     <Compile Remove="MAuthOwinTests.cs" />
     <Compile Remove="MAuthWebApiTests.cs" />
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Recently @awiesendangermdsol  incurred an issue and provided feedback that in updated MAuth , we have mentioned as support aspnetcore 2.0 and onwards but we had mix of references of  `Microsoft.AspNetcore.....2.2...` also.

Therefore, this PR is to address that problem and update all the aspnetcore versions to `2.1` which is LTS.

Please review:
@mdsol/architecture-enablement 
@hkurniawan-mdsol 
@mdsol/team-51 
@awiesendangermdsol 
