### PR TITLE
[Refactor] Refactor log message to same as ruby, java and python

### DIFF
--- a/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
+++ b/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
@@ -45,13 +45,15 @@ namespace Medidata.MAuth.Core
                 logger.LogInformation("Initiating Authentication of the request.");
                 var version = request.GetAuthHeaderValue().GetVersionFromAuthenticationHeader();
 
-                logger.LogInformation("Authentication is for the {version}.",version);
-
                 if (options.DisableV1 && version == MAuthVersion.MWS)
                     throw new InvalidVersionException($"Authentication with {version} version is disabled.");
 
                 var mAuthCore = MAuthCoreFactory.Instantiate(version);
                 var authInfo = GetAuthenticationInfo(request, version);
+                var logMessage = "Mauth-client attempting to authenticate request from app with mauth app uuid" +
+                        $" {authInfo.ApplicationUuid} using version {version}";
+                logger.LogInformation(logMessage);
+
                 var appInfo = await GetApplicationInfo(authInfo.ApplicationUuid, version).ConfigureAwait(false);
                 var signature = await mAuthCore.GetSignature(request, authInfo).ConfigureAwait(false);
 

--- a/tests/Medidata.MAuth.Tests/MAuthAuthenticatorTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthAuthenticatorTests.cs
@@ -41,11 +41,6 @@ namespace Medidata.MAuth.Tests
         {
             // Arrange
             var testData = await method.FromResource();
-
-            //var testOptions = TestExtensions.ServerOptions;
-            //testOptions.MAuthServerHandler = new MAuthServerHandler()
-            //    { AuthenticateOnlyV1 = true };
-
             var authenticator = new MAuthAuthenticator(TestExtensions.ServerOptions, NullLogger<MAuthAuthenticator>.Instance);
             var mAuthCore = new MAuthCore();
 


### PR DESCRIPTION
@ykitamura-mdsol pointed out that the log message in `mauth-client-dotnet` is not the same as other language and needs to be same in order to be searched for the logs later in sumologic.

Log message in `mauth-jvm-client`: https://github.com/mdsol/mauth-jvm-clients/blob/70d1767d744e46aa26aecbc3bafc91771c7565bd/modules/mauth-authenticator/src/main/java/com/mdsol/mauth/RequestAuthenticator.java#L94

Log message in `mauth-client-ruby`: https://github.com/mdsol/mauth-client-ruby/blob/v5.0.2/lib/mauth/client/authenticator_base.rb#L51-L53

Therefore, this PR is to refactor the log message it to have the same key phrase which is: `Mauth-client attempting to authenticate request from app`

Please review:
@ykitamura-mdsol 
@mdsol/architecture-enablement 
@mdsol/team-51 



