### PR TITLE
Update  MEL library in Medidata.MAuth.Core to 2.1 

### DIFF
--- a/src/Medidata.MAuth.Core/Medidata.MAuth.Core.csproj
+++ b/src/Medidata.MAuth.Core/Medidata.MAuth.Core.csproj
@@ -15,9 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />


### PR DESCRIPTION
One more, please 🙏 
Update MEL in `Medidata.MAuth.Core` to 2.1
Remove not used `MEL.Debug` and `MEL.Console` 

@awiesendangermdsol 
@hkurniawan-mdsol 
@mdsol/architecture-enablement 
