### PR TITLE
[MCC-575471] Fall back to V1 authentication when V2 authentication fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v4.0.2
 - **[AspNetCore]** Update aspnetcore version to aspnetcore2.1 LTS.
+- **[Core]** Fallback to V1 protocol when V2 athentication fails.
 
 ## v4.0.1
 - **[Core]** Fixed default sigining with both MWS and MWSV2 instead of option selected by consuming application.

--- a/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
+++ b/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
@@ -52,11 +52,11 @@ namespace Medidata.MAuth.Core
                         $" {options.ApplicationUuid} using version {version}";
                 logger.LogInformation(logMessage);
                 var authenticated = await Authenticate(request, version).ConfigureAwait(false);
-                if (version == MAuthVersion.MWSV2 && !authenticated && !options.DisableV1)
+                if (!authenticated && version == MAuthVersion.MWSV2 && !options.DisableV1)
                 {
                     // fall back to V1 authentication
                     authenticated = await Authenticate(request, MAuthVersion.MWS).ConfigureAwait(false);
-                    logger.LogWarning("Completed successful authentication attempt after fallback to v1");
+                    logger.LogWarning("Completed successful authentication attempt after fallback to V1");
                 }
                 return authenticated;
             }

--- a/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
+++ b/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
@@ -48,9 +48,6 @@ namespace Medidata.MAuth.Core
                 if (options.DisableV1 && version == MAuthVersion.MWS)
                     throw new InvalidVersionException($"Authentication with {version} version is disabled.");
 
-                var logMessage = "Mauth-client attempting to authenticate request from app with mauth app uuid" +
-                        $" {options.ApplicationUuid} using version {version}";
-                logger.LogInformation(logMessage);
                 var authenticated = await Authenticate(request, version).ConfigureAwait(false);
                 if (!authenticated && version == MAuthVersion.MWSV2 && !options.DisableV1)
                 {
@@ -94,6 +91,10 @@ namespace Medidata.MAuth.Core
 
         private async Task<bool> Authenticate(HttpRequestMessage request, MAuthVersion version)
         {
+            var logMessage = "Mauth-client attempting to authenticate request from app with mauth app uuid" +
+                             $" {options.ApplicationUuid} using version {version}";
+            logger.LogInformation(logMessage);
+
             var mAuthCore = MAuthCoreFactory.Instantiate(version);
             var authInfo = GetAuthenticationInfo(request, mAuthCore);
             var appInfo = await GetApplicationInfo(authInfo.ApplicationUuid).ConfigureAwait(false);

--- a/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
+++ b/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
@@ -94,10 +94,10 @@ namespace Medidata.MAuth.Core
 
         private async Task<bool> Authenticate(HttpRequestMessage request, MAuthVersion version)
         {
-            var authInfo = GetAuthenticationInfo(request, version);
+            var mAuthCore = MAuthCoreFactory.Instantiate(version);
+            var authInfo = GetAuthenticationInfo(request, mAuthCore);
             var appInfo = await GetApplicationInfo(authInfo.ApplicationUuid).ConfigureAwait(false);
 
-            var mAuthCore = MAuthCoreFactory.Instantiate(version);
             var signature = await mAuthCore.GetSignature(request, authInfo).ConfigureAwait(false);
             return mAuthCore.Verify(authInfo.Payload, signature, appInfo.PublicKey);
         }
@@ -130,11 +130,10 @@ namespace Medidata.MAuth.Core
         /// Extracts the authentication information from a <see cref="HttpRequestMessage"/>.
         /// </summary>
         /// <param name="request">The request that has the authentication information.</param>
-        /// <param name="version">Enum value of the MAuthVersion.</param>
+        /// <param name="mAuthCore">Instantiation of mAuthCore class.</param>
         /// <returns>The authentication information with the payload from the request.</returns>
-        internal PayloadAuthenticationInfo GetAuthenticationInfo(HttpRequestMessage request, MAuthVersion version)
+        internal PayloadAuthenticationInfo GetAuthenticationInfo(HttpRequestMessage request, IMAuthCore mAuthCore)
         {
-            var mAuthCore = MAuthCoreFactory.Instantiate(version);
             var headerKeys = mAuthCore.GetHeaderKeys();
             var authHeader = request.Headers.GetFirstValueOrDefault<string>(headerKeys.mAuthHeaderKey);
 

--- a/src/Medidata.MAuth.Core/MAuthRequestRetrier.cs
+++ b/src/Medidata.MAuth.Core/MAuthRequestRetrier.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Medidata.MAuth.Core.Models;
 
 namespace Medidata.MAuth.Core
 {
@@ -9,7 +8,7 @@ namespace Medidata.MAuth.Core
     {
         private readonly HttpClient client;
 
-        public MAuthRequestRetrier(MAuthOptionsBase options, MAuthVersion version)
+        public MAuthRequestRetrier(MAuthOptionsBase options)
         {
             var signingHandler = new MAuthSigningHandler(options: new MAuthSigningOptions()
             {

--- a/tests/Medidata.MAuth.Tests/Infrastructure/MAuthServerHandler.cs
+++ b/tests/Medidata.MAuth.Tests/Infrastructure/MAuthServerHandler.cs
@@ -29,7 +29,7 @@ namespace Medidata.MAuth.Tests.Infrastructure
 
             var authenticator = new MAuthAuthenticator(TestExtensions.ServerOptions, NullLogger<MAuthAuthenticator>.Instance);
 
-            var authInfo = authenticator.GetAuthenticationInfo(request, version);
+            var authInfo = authenticator.GetAuthenticationInfo(request, mAuthCore);
 
             if (!mAuthCore.Verify(authInfo.Payload, 
                 await mAuthCore.GetSignature(request, authInfo),

--- a/tests/Medidata.MAuth.Tests/Infrastructure/MAuthServerHandler.cs
+++ b/tests/Medidata.MAuth.Tests/Infrastructure/MAuthServerHandler.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Medidata.MAuth.Core;
-using Medidata.MAuth.Core.Models;
 using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json;
 
@@ -26,10 +25,7 @@ namespace Medidata.MAuth.Tests.Infrastructure
 
             if (currentNumberOfAttempts < SucceedAfterThisManyAttempts)
                 return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
-
-            var authenticator = new MAuthAuthenticator(TestExtensions.ServerOptions, NullLogger<MAuthAuthenticator>.Instance);
-
-            var authInfo = authenticator.GetAuthenticationInfo(request, mAuthCore);
+            var authInfo = MAuthAuthenticator.GetAuthenticationInfo(request, mAuthCore);
 
             if (!mAuthCore.Verify(authInfo.Payload, 
                 await mAuthCore.GetSignature(request, authInfo),

--- a/tests/Medidata.MAuth.Tests/MAuthAuthenticatorTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthAuthenticatorTests.cs
@@ -362,7 +362,7 @@ namespace Medidata.MAuth.Tests
             mockLogger.Verify(x => x.Log(
                     LogLevel.Warning, It.IsAny<EventId>(),
                     It.Is<FormattedLogValues>(v => v.ToString()
-                        .Contains("Completed successful authentication attempt after fallback to v1")),
+                        .Contains("Completed successful authentication attempt after fallback to V1")),
                     It.IsAny<Exception>(), It.IsAny<Func<object, Exception, string>>()
                 ));
         }
@@ -387,7 +387,7 @@ namespace Medidata.MAuth.Tests
             mockLogger.Verify(x => x.Log(
                 LogLevel.Warning, It.IsAny<EventId>(),
                 It.Is<FormattedLogValues>(v => v.ToString()
-                    .Contains("Completed successful authentication attempt after fallback to v1")),
+                    .Contains("Completed successful authentication attempt after fallback to V1")),
                 It.IsAny<Exception>(), It.IsAny<Func<object, Exception, string>>()
             ), Times.Never);
         }

--- a/tests/Medidata.MAuth.Tests/MAuthAuthenticatorTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthAuthenticatorTests.cs
@@ -312,9 +312,10 @@ namespace Medidata.MAuth.Tests
             var version = MAuthVersion.MWSV2;
             var testOptions = TestExtensions.ServerOptions;
             var authenticator = new MAuthAuthenticator(testOptions, NullLogger<MAuthAuthenticator>.Instance);
+            var mAuthCore = MAuthCoreFactory.Instantiate(version);
 
             // Act
-            var actual = authenticator.GetAuthenticationInfo(testData.ToHttpRequestMessage(version), version);
+            var actual = authenticator.GetAuthenticationInfo(testData.ToHttpRequestMessage(version), mAuthCore);
 
             // Assert
             Assert.Equal(testData.ApplicationUuid, actual.ApplicationUuid);
@@ -334,9 +335,10 @@ namespace Medidata.MAuth.Tests
             var version = MAuthVersion.MWS;
             var testOptions = TestExtensions.ServerOptions;
             var authenticator = new MAuthAuthenticator(testOptions, NullLogger<MAuthAuthenticator>.Instance);
+            var mAuthCore = MAuthCoreFactory.Instantiate(version);
 
             // Act
-            var actual = authenticator.GetAuthenticationInfo(testData.ToHttpRequestMessage(version), version);
+            var actual = authenticator.GetAuthenticationInfo(testData.ToHttpRequestMessage(version), mAuthCore);
 
             // Assert
             Assert.Equal(testData.ApplicationUuid, actual.ApplicationUuid);

--- a/tests/Medidata.MAuth.Tests/MAuthAuthenticatorTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthAuthenticatorTests.cs
@@ -311,11 +311,10 @@ namespace Medidata.MAuth.Tests
             var testData = await method.FromResourceV2();
             var version = MAuthVersion.MWSV2;
             var testOptions = TestExtensions.ServerOptions;
-            var authenticator = new MAuthAuthenticator(testOptions, NullLogger<MAuthAuthenticator>.Instance);
             var mAuthCore = MAuthCoreFactory.Instantiate(version);
 
             // Act
-            var actual = authenticator.GetAuthenticationInfo(testData.ToHttpRequestMessage(version), mAuthCore);
+            var actual = MAuthAuthenticator.GetAuthenticationInfo(testData.ToHttpRequestMessage(version), mAuthCore);
 
             // Assert
             Assert.Equal(testData.ApplicationUuid, actual.ApplicationUuid);
@@ -334,11 +333,10 @@ namespace Medidata.MAuth.Tests
             var testData = await method.FromResource();
             var version = MAuthVersion.MWS;
             var testOptions = TestExtensions.ServerOptions;
-            var authenticator = new MAuthAuthenticator(testOptions, NullLogger<MAuthAuthenticator>.Instance);
             var mAuthCore = MAuthCoreFactory.Instantiate(version);
 
             // Act
-            var actual = authenticator.GetAuthenticationInfo(testData.ToHttpRequestMessage(version), mAuthCore);
+            var actual = MAuthAuthenticator.GetAuthenticationInfo(testData.ToHttpRequestMessage(version), mAuthCore);
 
             // Assert
             Assert.Equal(testData.ApplicationUuid, actual.ApplicationUuid);

--- a/tests/Medidata.MAuth.Tests/Medidata.MAuth.Tests.csproj
+++ b/tests/Medidata.MAuth.Tests/Medidata.MAuth.Tests.csproj
@@ -71,6 +71,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
As discussed in this [doc](https://docs.google.com/document/d/1UsKJfZeDJb3cbvi0B-z-KMXHrNEGo-GKhXi2k4OnMxU/edit#heading=h.k5ec2aaqcyc0)
and same as in ruby [mdsol/mauth-client-ruby#38](https://github.com/mdsol/mauth-client-ruby/pull/38), this PR updates the logic to fall back to V1 authentication when V2 authentication fails.

Please review:
@mdsol/architecture-enablement 
@mdsol/team-51 