### PR TITLE
[MCC-638856] Remove double encoding for query params and normalize path for V2 signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes in Medidata.MAuth
 
+## v4.0.3
+ - **[Core]** Added normalization of Uri AbsolutePath.
+ - **[Core]** Added unescape step in query_string encoding to remove `double encoding`.
+
 ## v4.0.2
 - **[AspNetCore]** Update aspnetcore version to aspnetcore2.1 LTS.
 - **[Core]** Fallback to V1 protocol when V2 athentication fails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changes in Medidata.MAuth
 
-## v4.0.3
+## v4.1.0
  - **[Core]** Added normalization of Uri AbsolutePath.
  - **[Core]** Added unescape step in query_string encoding to remove `double encoding`.
 

--- a/src/Medidata.MAuth.Core/Constants.cs
+++ b/src/Medidata.MAuth.Core/Constants.cs
@@ -45,5 +45,9 @@ namespace Medidata.MAuth.Core
         public static readonly string MAuthTimeHeaderKeyV2 = "MCC-Time";
 
         public static readonly string MAuthTokenRequestPath = "/mauth/v1/security_tokens/";
+
+        public static readonly Regex LowerCaseHexPattern = new Regex("%[a-f0-9]{2}", RegexOptions.Compiled);
+
+        public static readonly Regex SlashPattern = new Regex("//+", RegexOptions.Compiled);
     }
 }

--- a/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
+++ b/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
@@ -235,8 +235,8 @@ namespace Medidata.MAuth.Core
                 match = match.NextMatch();
             }
 
-            // Replacing "//" and "///" into single "/"
-            normalizedPath = normalizedPath.Replace("///", "/").Replace("//", "/");
+            // Replaces multiple slashes into single "/"
+            normalizedPath = Regex.Replace(normalizedPath, "//+", "/");
 
             return normalizedPath; 
         }

--- a/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
+++ b/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
@@ -198,6 +198,7 @@ namespace Medidata.MAuth.Core
                 unEscapedQueryStrings.Add($"{unEscapedKey}={unEscapedValue}");
             });
             var unEscapedQueryArray = unEscapedQueryStrings.ToArray();
+
             Array.Sort(unEscapedQueryArray, StringComparer.Ordinal);
             Array.ForEach(unEscapedQueryArray, x =>
             {

--- a/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
+++ b/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
@@ -207,7 +207,12 @@ namespace Medidata.MAuth.Core
                 encodedQueryStrings.Add($"{escapedKey}={escapedValue}");
             });
             var result = string.Join("&", encodedQueryStrings);
-            return result.Replace("%2B","%20");
+
+            // Above encoding converts space as `%20` and `+` as `%2B`
+            // But space and `+` both needs to be converted as `%20` as per
+            // reference https://github.com/mdsol/mauth-client-ruby/blob/master/lib/mauth/request_and_response.rb#L113
+            // so this convert `%2B` into `%20` to match encodedqueryparams to that of other languages.
+            return result.Replace("%2B", "%20");
         }
 
         /// <summary>
@@ -233,8 +238,6 @@ namespace Medidata.MAuth.Core
             // Replacing "//" and "///" into single "/"
             normalizedPath = normalizedPath.Replace("///", "/").Replace("//", "/");
 
-            if (!normalizedPath.EndsWith("/") && (path.EndsWith("/") || path.EndsWith("/.") || path.EndsWith("/..")))
-                normalizedPath = $"{normalizedPath}/";
             return normalizedPath; 
         }
     }

--- a/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
+++ b/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
@@ -192,10 +192,10 @@ namespace Medidata.MAuth.Core
             // unescaping
             for (int i = 0; i < queryArray.Length; i++)
             {
-                var keyValue = queryArray.ElementAt(i).Split('=');
+                var keyValue = queryArray[i].Split('=');
                 var unEscapedKey = Uri.UnescapeDataString(keyValue[0]);
                 var unEscapedValue = Uri.UnescapeDataString(keyValue[1]);
-                queryArray[i] = queryArray[i].Replace(queryArray.ElementAt(i), $"{unEscapedKey}={unEscapedValue}");
+                queryArray[i] = $"{unEscapedKey}={unEscapedValue}";
             }
 
             // sorting
@@ -204,10 +204,10 @@ namespace Medidata.MAuth.Core
             // escaping
             for (int i = 0; i < queryArray.Length; i++)
             {
-                var keyValue = queryArray.ElementAt(i).Split('=');
+                var keyValue = queryArray[i].Split('=');
                 var escapedKey = Uri.EscapeDataString(keyValue[0]);
                 var escapedValue = Uri.EscapeDataString(keyValue[1]);
-                queryArray[i] = queryArray[i].Replace(queryArray.ElementAt(i), $"{escapedKey}={escapedValue}");
+                queryArray[i] = $"{escapedKey}={escapedValue}";
             }
 
             // Above encoding converts space as `%20` and `+` as `%2B`

--- a/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
+++ b/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
@@ -228,15 +228,15 @@ namespace Medidata.MAuth.Core
                 return string.Empty;
 
             // Normalize percent encoding to uppercase i.e. %cf%80 => %CF%80
-            var match = new Regex("%[a-f0-9]{2}").Match(path);
-            while(match.Success)
+            var matches = Constants.LowerCaseHexPattern.Matches(path);
+            var normalizedPath = new StringBuilder(path);
+            foreach(var item in matches)
             {
-                path = path.Replace(match.Value, match.Value.ToUpperInvariant());
-                match = match.NextMatch();
+                normalizedPath.Replace(item.ToString(), item.ToString().ToUpper());
             }
 
             // Replaces multiple slashes into single "/"
-            return new Regex("//+").Replace(path, "/");
+            return Constants.SlashPattern.Replace(normalizedPath.ToString(), "/");
         }
     }
 }

--- a/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
+++ b/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
@@ -210,7 +210,7 @@ namespace Medidata.MAuth.Core
 
             // Above encoding converts space as `%20` and `+` as `%2B`
             // But space and `+` both needs to be converted as `%20` as per
-            // reference https://github.com/mdsol/mauth-client-ruby/blob/master/lib/mauth/request_and_response.rb#L113
+            // reference https://github.com/mdsol/mauth-client-ruby/blob/v6.0.0/lib/mauth/request_and_response.rb#L113
             // so this convert `%2B` into `%20` to match encodedqueryparams to that of other languages.
             return result.Replace("%2B", "%20");
         }

--- a/src/Medidata.MAuth.Core/MAuthCoreV2.cs
+++ b/src/Medidata.MAuth.Core/MAuthCoreV2.cs
@@ -69,8 +69,7 @@ namespace Medidata.MAuth.Core
             var encodedCurrentSecondsSinceEpoch = authInfo.SignedTime.ToUnixTimeSeconds().ToString().ToBytes();
             var queryString = request.RequestUri.Query;
             var encodedQueryParams = !string.IsNullOrEmpty(queryString) 
-                ? queryString.Substring(queryString.IndexOf("?") + 1, queryString.Length - 1)
-                    .BuildEncodedQueryParams().ToBytes() 
+                ? queryString.Substring(1).BuildEncodedQueryParams().ToBytes()
                 : new byte[] { };
 
             return new byte[][]

--- a/src/Medidata.MAuth.Core/MAuthCoreV2.cs
+++ b/src/Medidata.MAuth.Core/MAuthCoreV2.cs
@@ -59,7 +59,7 @@ namespace Medidata.MAuth.Core
         public async Task<byte[]> GetSignature(HttpRequestMessage request, AuthenticationInfo authInfo)
         {
             var encodedHttpVerb = request.Method.Method.ToBytes();
-            var encodedResourceUriPath = request.RequestUri.AbsolutePath.ToBytes();
+            var encodedResourceUriPath = request.RequestUri.AbsolutePath.NormalizeUriPath().ToBytes();
             var encodedAppUUid = authInfo.ApplicationUuid.ToHyphenString().ToBytes();
 
             var requestBody = request.Content != null ?
@@ -67,8 +67,11 @@ namespace Medidata.MAuth.Core
             var requestBodyDigest = requestBody.AsSHA512Hash();
 
             var encodedCurrentSecondsSinceEpoch = authInfo.SignedTime.ToUnixTimeSeconds().ToString().ToBytes();
-            var encodedQueryParams = !string.IsNullOrEmpty(request.RequestUri.Query) ?
-                request.RequestUri.Query.Replace("?", "").BuildEncodedQueryParams().ToBytes() : new byte[] { };
+            var queryString = request.RequestUri.Query;
+            var encodedQueryParams = !string.IsNullOrEmpty(queryString) 
+                ? queryString.Substring(queryString.IndexOf("?") + 1, queryString.Length - 1)
+                    .BuildEncodedQueryParams().ToBytes() 
+                : new byte[] { };
 
             return new byte[][]
             {

--- a/tests/Medidata.MAuth.Tests/MAuthCoreExtensionsTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthCoreExtensionsTests.cs
@@ -67,31 +67,20 @@ namespace Medidata.MAuth.Tests
             Assert.Empty(path.NormalizeUriPath());
         }
 
-        [Fact]
-        public static void NormalizeUriPath_WithValues()
+        [Theory]
+        [InlineData("/example/sample", "/example/sample")]
+        [InlineData("/example//sample/", "/example/sample/")]
+        [InlineData("//example///sample/", "/example/sample/")]
+        [InlineData("/%2a%80", "/%2A%80")]
+        [InlineData("/example/", "/example/")]
+        [InlineData("/example/sample/..", "/example/")]
+        [InlineData("/example/sample/../../../..", "/")]
+        [InlineData("/example//./.", "/example/")]
+        [InlineData("/./example/./.", "/example/")]
+        public static void NormalizeUriPath_WithValues(string input, string expected)
         {
-            var testcases = CreateUriPathArray();
-            for(int i = 0; i <= testcases.GetUpperBound(0); i++)
-            {
-                var request = new Uri("http://localhost:2999" + testcases[i, 0]);
-               Assert.Equal(testcases[i,1], request.AbsolutePath.NormalizeUriPath());
-            }
-        }
-
-        private static string [ , ] CreateUriPathArray()
-        {
-            return new string [10, 2] {
-                { "/example/sample", "/example/sample"},
-                {"/example//sample/", "/example/sample/"},
-                {"//example///sample/", "/example/sample/"},
-                {"/%2a%80", "/%2A%80"},
-                { "/example/", "/example/" },
-                {"/example/sample/..", "/example/"},
-                {"/example/sample/..", "/example/"},
-                {"/example/sample/../../../..", "/"},
-                {"/example//./.", "/example/"},
-                {"/./example/./.", "/example/"}
-            };
+            var request = new Uri("http://localhost:2999" + input);
+            Assert.Equal(expected, request.AbsolutePath.NormalizeUriPath());
         }
     }
 }

--- a/tests/Medidata.MAuth.Tests/MAuthCoreExtensionsTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthCoreExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using Medidata.MAuth.Core;
+using System;
 using Xunit;
 
 namespace Medidata.MAuth.Tests
@@ -9,7 +10,7 @@ namespace Medidata.MAuth.Tests
         public static void BuildEncodedQueryParams_WillEncodeQueryStringWithSpecialCharacters()
         {
             var queryString = "key=-_.~!@#$%^*()+{}|:\"'`<>?";
-            var expected = "key=-_.~%21%40%23%24%25%5E%2A%28%29%2B%7B%7D%7C%3A%22%27%60%3C%3E%3F";
+            var expected = "key=-_.~%21%40%23%24%25%5E%2A%28%29%20%7B%7D%7C%3A%22%27%60%3C%3E%3F";
             Assert.Equal(queryString.BuildEncodedQueryParams(), expected);
         }
 
@@ -34,6 +35,63 @@ namespace Medidata.MAuth.Tests
         {
             var queryString = "k=&k=v";
             Assert.Equal(queryString.BuildEncodedQueryParams(), queryString);
+        }
+
+        [Fact]
+        public static void BuildEncodedQueryParams_WithUnescapedTilda()
+        {
+            var queryString = "k=%7E";
+            var expectedString = "k=~";
+            Assert.Equal(expectedString, queryString.BuildEncodedQueryParams());
+        }
+
+        [Fact]
+        public static void BuildEncodedQueryParams_SortAfterUnescaping()
+        {
+            var queryString = "k=%7E&k=~&k=%40&k=a";
+            var expectedString = "k=%40&k=a&k=~&k=~";
+            Assert.Equal(expectedString, queryString.BuildEncodedQueryParams());
+        }
+
+        [Fact]
+        public static void BuildEncodedQueryParams_WithNullQueryString()
+        {
+            string queryString = null;
+            Assert.Empty(queryString.BuildEncodedQueryParams());
+        }
+
+        [Fact]
+        public static void NormalizeUriPath_WithNullPath()
+        {
+            string path =null;
+            Assert.Empty(path.NormalizeUriPath());
+        }
+
+        [Fact]
+        public static void NormalizeUriPath_WithValues()
+        {
+            var testcases = CreateUriPathArray();
+            for(int i = 0; i <= testcases.GetUpperBound(0); i++)
+            {
+                var request = new Uri("http://localhost:2999" + testcases[i, 0]);
+               Assert.Equal(testcases[i,1], request.AbsolutePath.NormalizeUriPath());
+            }
+        }
+
+        private static string [ , ] CreateUriPathArray()
+        {
+            return new string [10, 2] {
+                { "/example/sample", "/example/sample"},
+                {"/example//sample/", "/example/sample/"},
+                {"//example///sample/", "/example/sample/"},
+                {"/%2a%80", "/%2A%80"},
+                { "/example/", "/example/" },
+                {"/example/sample/..", "/example/"},
+                {"/example/sample/..", "/example/"},
+                {"/example/sample/../../../..", "/"},
+                {"/example//./.", "/example/"},
+                {"/./example/./.", "/example/"}
+            };
         }
     }
 }

--- a/tests/Medidata.MAuth.Tests/MAuthCoreV2Tests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthCoreV2Tests.cs
@@ -97,7 +97,7 @@ namespace Medidata.MAuth.Tests
             var expectedSignature = new byte[][]
             {
                 testData.Method.ToBytes(), Constants.NewLine,
-                testData.Url.AbsolutePath.ToBytes(), Constants.NewLine,
+                testData.Url.AbsolutePath.NormalizeUriPath().ToBytes(), Constants.NewLine,
                 content.AsSHA512Hash(), Constants.NewLine,
                 testData.ApplicationUuidString.ToBytes(), Constants.NewLine,
                 testData.SignedTimeUnixSeconds.ToString().ToBytes(), Constants.NewLine,

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>4.0.2</Version>
+    <Version>4.0.3</Version>
   </PropertyGroup>
 </Project>

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>4.0.3</Version>
+    <Version>4.1.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR implements

- Removal of "double encoding" of query string parameters and uses the same approach as that of other languages as `ruby, python and java`.  (Note: Encodes `%2B` -> `%20`  to match that of other languages.)
- Adding normalization of the `requestUri path`.
- Updated the `Changelog` and `version.props`.
- Updated the log message during  Authentication to same as that of other langs `ruby`and `python`.

Please review:
@mdsol/architecture-enablement 
@mdsol/team-51 
@mdsol/libraries_dotnet 