### PR TITLE
[MCC-638046] Make the signing protocol versions configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v5.0.0
  - **[Core]** Added normalization of Uri AbsolutePath.
  - **[Core]** Added unescape step in query_string encoding to remove `double encoding`.
- - **[Core]** Replace `DisableV1`option with `SignVersions` option and change the default signing to `MAuthVersion.MWSV2` only.
+ - **[Core]** Replace `DisableV1`option with `SignVersions` option and change the default signing to `MAuthVersion.MWS` only.
 
 ## v4.0.2
 - **[AspNetCore]** Update aspnetcore version to aspnetcore2.1 LTS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v4.1.0
  - **[Core]** Added normalization of Uri AbsolutePath.
  - **[Core]** Added unescape step in query_string encoding to remove `double encoding`.
- - **[Core]** Replace `DisableV1`option with `SigningOptions` option and change the default to `v2` only.
+ - **[Core]** Replace `DisableV1`option with `SignVersions` option and change the default to `v2` only.
 
 ## v4.0.2
 - **[AspNetCore]** Update aspnetcore version to aspnetcore2.1 LTS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v4.1.0
  - **[Core]** Added normalization of Uri AbsolutePath.
  - **[Core]** Added unescape step in query_string encoding to remove `double encoding`.
+ - **[Core]** Replace `DisableV1`option with `SigningOptions` option and change the default to `v2` only.
 
 ## v4.0.2
 - **[AspNetCore]** Update aspnetcore version to aspnetcore2.1 LTS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changes in Medidata.MAuth
 
-## v4.1.0
+## v5.0.0
  - **[Core]** Added normalization of Uri AbsolutePath.
  - **[Core]** Added unescape step in query_string encoding to remove `double encoding`.
  - **[Core]** Replace `DisableV1`option with `SignVersions` option and change the default to `v2` only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v5.0.0
  - **[Core]** Added normalization of Uri AbsolutePath.
  - **[Core]** Added unescape step in query_string encoding to remove `double encoding`.
- - **[Core]** Replace `DisableV1`option with `SignVersions` option and change the default to `v2` only.
+ - **[Core]** Replace `DisableV1`option with `SignVersions` option and change the default signing to `MAuthVersion.MWSV2` only.
 
 ## v4.0.2
 - **[AspNetCore]** Update aspnetcore version to aspnetcore2.1 LTS.

--- a/README.md
+++ b/README.md
@@ -114,9 +114,8 @@ public async Task<HttpResponseMessage> SignAndSendRequest(HttpRequestMessage req
         // The following can be either a path to the key file or the contents of the file itself
         PrivateKey = "ClientPrivateKey.pem",
 
-        // when ready to disable authentication of V1 protocol else default is false
-        // signs with both V1 and V2.
-        DisableV1 = true
+        // comma-separated values of signing protocols, if not provided defaults to v2 
+        SigningOptions = "v1,v2"
     });
 
     using (var client = new HttpClient(signingHandler))
@@ -125,9 +124,11 @@ public async Task<HttpResponseMessage> SignAndSendRequest(HttpRequestMessage req
     }
 }
 ```
-With the release of support for MAuth V2 protocol, by default MAuth request signs with both V1 and V2 protocol.
-Also by default, `DisableV1` option is set to false (if not included). When we are ready to 
-disable all the V1 request, then we need to include this disable option as : `DisableV1 = true`. 
+The `SigningOptions` parameter can be used to specify which protocol version to sign outgoing requests. Like as:
+`SigningOptions ="v1"`: signs with v1 protocol only.
+`SigningOptions ="v1, v2"` : signs with both v1 and v2 protocol.
+If not supplied, it sign by `v2` by default.
+
 Signing with V2 protocol supports query string.
 
 The example above is creating a new instance of a `HttpClient` with the handler responsible for signing the
@@ -139,7 +140,7 @@ The `MAuthSigningOptions` has the following properties to determine the required
 | ---- | ----------- |
 | **ApplicationUuid** | Determines the unique identifier of the client application used for the MAuth service authentication requests.  This uuid needs to be registered with the MAuth Server in order for the authenticating server application to be able to authenticate the signed request. |
 | **PrivateKey** | Determines the RSA private key of the client for signing a request. This key must be in a PEM ASN.1 format. The value of this property can be set as a valid path to a readable key file as well. |
-| **DisableV1** | Determines the boolean value which controls whether to disable the signing requests with V1 protocol or not. If not supplied, this value is `false`. |
+| **SigningOptions** | (optional) Comma-separated protocol versions to sign requests. If not supplied, defaults to `v2`.
 
 ### Authenticating Incoming Requests with the OWIN and ASP.NET Core Middlewares
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ public async Task<HttpResponseMessage> SignAndSendRequest(HttpRequestMessage req
         PrivateKey = "ClientPrivateKey.pem",
 
         // Enumerations of signing protocols, if not provided defaults to `MAuthVersion.MWSV2`for sign-in.
-        SignVersions = new List<MAuthVersion> { MAuthVersion.MWS, MAuthVersion.MWSV2 }
+        SignVersions = MAuthVersion.MWS | MAuthVersion.MWSV2
     });
 
     using (var client = new HttpClient(signingHandler))
@@ -125,8 +125,8 @@ public async Task<HttpResponseMessage> SignAndSendRequest(HttpRequestMessage req
 }
 ```
 The `SignVersions` parameter can be used to specify which protocol version to sign outgoing requests. Like as:  
-`SignVersions =new List<MAuthVersion> { MAuthVersion.MWS }`: signs with `MWS` protocol only.  
-`SignVersions =new List<MAuthVersion> { MAuthVersion.MWS, MAuthVersion.MWSV2 }` : signs with both `MWS` and `MWSV2` protocol.  
+`SignVersions = MAuthVersion.MWS`: signs with `MWS` protocol only.  
+`SignVersions = MAuthVersion.MWS | MAuthVersion.MWSV2` : signs with both `MWS` and `MWSV2` protocol.  
 If not supplied, it sign by `MWSV2` protocol by default.
 
 Signing with `MWSV2` protocol supports query string.

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ public async Task<HttpResponseMessage> SignAndSendRequest(HttpRequestMessage req
     }
 }
 ```
-The `SignVersions` parameter can be used to specify which protocol version to sign outgoing requests. Like as:
-`SignVersions ="v1"`: signs with v1 protocol only.
-`SignVersions ="v1, v2"` : signs with both v1 and v2 protocol.
+The `SignVersions` parameter can be used to specify which protocol version to sign outgoing requests. Like as:  
+`SignVersions ="v1"`: signs with v1 protocol only.  
+`SignVersions ="v1, v2"` : signs with both v1 and v2 protocol.  
 If not supplied, it sign by `v2` by default.
 
 Signing with V2 protocol supports query string.
@@ -330,6 +330,11 @@ of V1 protcol, we are still maintaining the BouncyCastle library as mentioned be
 On the .NET Framework side (WebAPI, Owin, Core) we are using the latest version (as of date 1.81) of the
 [BouncyCastle](https://github.com/bcgit/bc-csharp) library; on the .NET Standard side (Core, AspNetCore) we are using
 the portable fork of the [BouncyCastle](https://github.com/onovotny/BouncyCastle-PCL) library.
+
+##### What are the major changes in the 5.0.0 version?
+In this version we have removed the property `DisableV1` from `MAuthSigningOptions`. Instead, we have added new option as 
+`SignVersions` in `MAuthSigningOptions` which takes comma-separated values of "v1" and "v2" protocol. If this option is not 
+provided, then it will sign in by "v2" protocol as default. 
 
 ##### What are the major changes in the 4.0.0 version?
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ public async Task<HttpResponseMessage> SignAndSendRequest(HttpRequestMessage req
         // The following can be either a path to the key file or the contents of the file itself
         PrivateKey = "ClientPrivateKey.pem",
 
-        // comma-separated values of signing protocols, if not provided defaults to v2 
-        SignVersions = "v1,v2"
+        // Enumerations of signing protocols, if not provided defaults to `MAuthVersion.MWSV2`for sign-in.
+        SignVersions = new List<MAuthVersion> { MAuthVersion.MWS, MAuthVersion.MWSV2 }
     });
 
     using (var client = new HttpClient(signingHandler))
@@ -125,11 +125,11 @@ public async Task<HttpResponseMessage> SignAndSendRequest(HttpRequestMessage req
 }
 ```
 The `SignVersions` parameter can be used to specify which protocol version to sign outgoing requests. Like as:  
-`SignVersions ="v1"`: signs with v1 protocol only.  
-`SignVersions ="v1, v2"` : signs with both v1 and v2 protocol.  
-If not supplied, it sign by `v2` by default.
+`SignVersions =new List<MAuthVersion> { MAuthVersion.MWS }`: signs with `MWS` protocol only.  
+`SignVersions =new List<MAuthVersion> { MAuthVersion.MWS, MAuthVersion.MWSV2 }` : signs with both `MWS` and `MWSV2` protocol.  
+If not supplied, it sign by `MWSV2` protocol by default.
 
-Signing with V2 protocol supports query string.
+Signing with `MWSV2` protocol supports query string.
 
 The example above is creating a new instance of a `HttpClient` with the handler responsible for signing the
 requests and sends the request to its designation. Finally it returns the response from the remote server.
@@ -140,7 +140,7 @@ The `MAuthSigningOptions` has the following properties to determine the required
 | ---- | ----------- |
 | **ApplicationUuid** | Determines the unique identifier of the client application used for the MAuth service authentication requests.  This uuid needs to be registered with the MAuth Server in order for the authenticating server application to be able to authenticate the signed request. |
 | **PrivateKey** | Determines the RSA private key of the client for signing a request. This key must be in a PEM ASN.1 format. The value of this property can be set as a valid path to a readable key file as well. |
-| **SignVersions** | (optional) Comma-separated protocol versions to sign requests. If not supplied, defaults to `v2`.
+| **SignVersions** | (optional) Enumerations of MAuth protocol versions to sign requests. If not supplied, defaults to `MWSV2`.
 
 ### Authenticating Incoming Requests with the OWIN and ASP.NET Core Middlewares
 
@@ -333,8 +333,8 @@ the portable fork of the [BouncyCastle](https://github.com/onovotny/BouncyCastle
 
 ##### What are the major changes in the 5.0.0 version?
 In this version we have removed the property `DisableV1` from `MAuthSigningOptions`. Instead, we have added new option as 
-`SignVersions` in `MAuthSigningOptions` which takes comma-separated values of "v1" and "v2" protocol. If this option is not 
-provided, then it will sign in by "v2" protocol as default. 
+`SignVersions` in `MAuthSigningOptions` which takes enumeration values of MAuth protcol versions `MWS` and/ or `MWSV2` protocol. 
+If this option is not provided, then it will sign in by `MWSV2` protocol as default. 
 
 ##### What are the major changes in the 4.0.0 version?
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ public async Task<HttpResponseMessage> SignAndSendRequest(HttpRequestMessage req
         PrivateKey = "ClientPrivateKey.pem",
 
         // comma-separated values of signing protocols, if not provided defaults to v2 
-        SigningOptions = "v1,v2"
+        SignVersions = "v1,v2"
     });
 
     using (var client = new HttpClient(signingHandler))
@@ -124,9 +124,9 @@ public async Task<HttpResponseMessage> SignAndSendRequest(HttpRequestMessage req
     }
 }
 ```
-The `SigningOptions` parameter can be used to specify which protocol version to sign outgoing requests. Like as:
-`SigningOptions ="v1"`: signs with v1 protocol only.
-`SigningOptions ="v1, v2"` : signs with both v1 and v2 protocol.
+The `SignVersions` parameter can be used to specify which protocol version to sign outgoing requests. Like as:
+`SignVersions ="v1"`: signs with v1 protocol only.
+`SignVersions ="v1, v2"` : signs with both v1 and v2 protocol.
 If not supplied, it sign by `v2` by default.
 
 Signing with V2 protocol supports query string.
@@ -140,7 +140,7 @@ The `MAuthSigningOptions` has the following properties to determine the required
 | ---- | ----------- |
 | **ApplicationUuid** | Determines the unique identifier of the client application used for the MAuth service authentication requests.  This uuid needs to be registered with the MAuth Server in order for the authenticating server application to be able to authenticate the signed request. |
 | **PrivateKey** | Determines the RSA private key of the client for signing a request. This key must be in a PEM ASN.1 format. The value of this property can be set as a valid path to a readable key file as well. |
-| **SigningOptions** | (optional) Comma-separated protocol versions to sign requests. If not supplied, defaults to `v2`.
+| **SignVersions** | (optional) Comma-separated protocol versions to sign requests. If not supplied, defaults to `v2`.
 
 ### Authenticating Incoming Requests with the OWIN and ASP.NET Core Middlewares
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ public async Task<HttpResponseMessage> SignAndSendRequest(HttpRequestMessage req
         // The following can be either a path to the key file or the contents of the file itself
         PrivateKey = "ClientPrivateKey.pem",
 
-        // Enumerations of signing protocols, if not provided defaults to `MAuthVersion.MWSV2`for sign-in.
+        // Enumerations of signing protocols, if not provided defaults to `MAuthVersion.MWS`for sign-in.
         SignVersions = MAuthVersion.MWS | MAuthVersion.MWSV2
     });
 
@@ -127,7 +127,7 @@ public async Task<HttpResponseMessage> SignAndSendRequest(HttpRequestMessage req
 The `SignVersions` parameter can be used to specify which protocol version to sign outgoing requests. Like as:  
 `SignVersions = MAuthVersion.MWS`: signs with `MWS` protocol only.  
 `SignVersions = MAuthVersion.MWS | MAuthVersion.MWSV2` : signs with both `MWS` and `MWSV2` protocol.  
-If not supplied, it sign by `MWSV2` protocol by default.
+If not supplied, it sign by `MWS` protocol by default.
 
 Signing with `MWSV2` protocol supports query string.
 
@@ -140,7 +140,7 @@ The `MAuthSigningOptions` has the following properties to determine the required
 | ---- | ----------- |
 | **ApplicationUuid** | Determines the unique identifier of the client application used for the MAuth service authentication requests.  This uuid needs to be registered with the MAuth Server in order for the authenticating server application to be able to authenticate the signed request. |
 | **PrivateKey** | Determines the RSA private key of the client for signing a request. This key must be in a PEM ASN.1 format. The value of this property can be set as a valid path to a readable key file as well. |
-| **SignVersions** | (optional) Enumerations of MAuth protocol versions to sign requests. If not supplied, defaults to `MWSV2`.
+| **SignVersions** | (optional) Enumerations of MAuth protocol versions to sign requests. If not supplied, defaults to `MWS`.
 
 ### Authenticating Incoming Requests with the OWIN and ASP.NET Core Middlewares
 
@@ -334,7 +334,7 @@ the portable fork of the [BouncyCastle](https://github.com/onovotny/BouncyCastle
 ##### What are the major changes in the 5.0.0 version?
 In this version we have removed the property `DisableV1` from `MAuthSigningOptions`. Instead, we have added new option as 
 `SignVersions` in `MAuthSigningOptions` which takes enumeration values of MAuth protcol versions `MWS` and/ or `MWSV2` protocol. 
-If this option is not provided, then it will sign in by `MWSV2` protocol as default. 
+If this option is not provided, then it will sign in by `MWS` protocol as default. 
 
 ##### What are the major changes in the 4.0.0 version?
 

--- a/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
+++ b/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
@@ -58,7 +58,7 @@ namespace Medidata.MAuth.Core
             if (InnerHandler == null)
                 InnerHandler = new HttpClientHandler();
 
-            var signingVersions = GetSigningVersions(options.SigningOptions);
+            var signingVersions = GetSigningVersions(options.SignVersions);
             foreach(var version in signingVersions)
             {
                 var mAuthCore = MAuthCoreFactory.Instantiate(version);
@@ -70,12 +70,12 @@ namespace Medidata.MAuth.Core
                 .ConfigureAwait(continueOnCapturedContext: false);
         }
 
-        private List<MAuthVersion> GetSigningVersions(string signingOptions)
+        private IEnumerable<MAuthVersion> GetSigningVersions(string signingOptions)
         {
-            var signVersions = new List<MAuthVersion>();
             if (string.IsNullOrEmpty(signingOptions))
                 return new List<MAuthVersion>() { MAuthVersion.MWSV2 };
 
+            var signVersions = new List<MAuthVersion>();
             var signingArray = signingOptions.ToLower().Split(',');
             foreach(var item in signingArray)
             {
@@ -89,6 +89,7 @@ namespace Medidata.MAuth.Core
                         break;
                 }
             }
+
             if(signingArray.Any() && !signVersions.Any())
                 throw new InvalidVersionException($"Signing with {signingOptions} version is not allowed.");
 

--- a/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
+++ b/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
@@ -25,7 +25,7 @@ namespace Medidata.MAuth.Core
         public MAuthSigningHandler(MAuthSigningOptions options)
         {
             this.options = options;
-            this.options.SignVersions = options.SignVersions ?? MAuthVersion.MWSV2;
+            this.options.SignVersions = options.SignVersions;
         }
 
         /// <summary>
@@ -39,7 +39,7 @@ namespace Medidata.MAuth.Core
         public MAuthSigningHandler(MAuthSigningOptions options, HttpMessageHandler innerHandler): base(innerHandler)
         {
             this.options = options;
-            this.options.SignVersions = options.SignVersions ?? MAuthVersion.MWSV2;
+            this.options.SignVersions = options.SignVersions;
         }
 
         /// <summary>

--- a/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
+++ b/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
@@ -25,7 +25,6 @@ namespace Medidata.MAuth.Core
         public MAuthSigningHandler(MAuthSigningOptions options)
         {
             this.options = options;
-            this.options.SignVersions = options.SignVersions;
         }
 
         /// <summary>
@@ -39,7 +38,6 @@ namespace Medidata.MAuth.Core
         public MAuthSigningHandler(MAuthSigningOptions options, HttpMessageHandler innerHandler): base(innerHandler)
         {
             this.options = options;
-            this.options.SignVersions = options.SignVersions;
         }
 
         /// <summary>

--- a/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
+++ b/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
@@ -77,7 +77,8 @@ namespace Medidata.MAuth.Core
 
             var mauthVersions = new List<MAuthVersion>();
             var signingArray = signingVersions.ToLower().Split(',');
-            foreach(var item in signingArray)
+
+            foreach (var item in signingArray)
             {
                 switch (item.Trim())
                 {
@@ -90,7 +91,7 @@ namespace Medidata.MAuth.Core
                 }
             }
 
-            if(signingArray.Any() && !mauthVersions.Any())
+            if (signingArray.Any() && !mauthVersions.Any())
                 throw new InvalidVersionException($"Signing with {signingVersions} version is not allowed.");
 
             return mauthVersions;

--- a/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
+++ b/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
@@ -12,10 +12,10 @@ namespace Medidata.MAuth.Core
     /// </summary>
     public class MAuthSigningHandler: DelegatingHandler
     {
-        private readonly MAuthSigningOptions options;
+        private readonly MAuthSigningOptions _options;
 
         /// <summary>Gets the Uuid of the client application.</summary>
-        public Guid ClientAppUuid => options.ApplicationUuid;
+        public Guid ClientAppUuid => _options.ApplicationUuid;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MAuthSigningHandler"/> class with the provided
@@ -24,7 +24,7 @@ namespace Medidata.MAuth.Core
         /// <param name="options">The options for this message handler.</param>
         public MAuthSigningHandler(MAuthSigningOptions options)
         {
-            this.options = options;
+            _options = options;
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Medidata.MAuth.Core
         /// </param>
         public MAuthSigningHandler(MAuthSigningOptions options, HttpMessageHandler innerHandler): base(innerHandler)
         {
-            this.options = options;
+            _options = options;
         }
 
         /// <summary>
@@ -56,10 +56,10 @@ namespace Medidata.MAuth.Core
 
             foreach (MAuthVersion version in Enum.GetValues(typeof(MAuthVersion)))
             {
-                if (options.SignVersions.HasFlag(version))
+                if (_options.SignVersions.HasFlag(version))
                 {
                     var mAuthCore = MAuthCoreFactory.Instantiate(version);
-                    request = await mAuthCore.Sign(request, options).ConfigureAwait(false);
+                    request = await mAuthCore.Sign(request, _options).ConfigureAwait(false);
                 }
             }
 

--- a/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
+++ b/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,7 +25,7 @@ namespace Medidata.MAuth.Core
         public MAuthSigningHandler(MAuthSigningOptions options)
         {
             this.options = options;
-            this.options.SignVersions = options.SignVersions ?? new List<MAuthVersion> { MAuthVersion.MWSV2 };
+            this.options.SignVersions = options.SignVersions ?? MAuthVersion.MWSV2;
         }
 
         /// <summary>
@@ -40,7 +39,7 @@ namespace Medidata.MAuth.Core
         public MAuthSigningHandler(MAuthSigningOptions options, HttpMessageHandler innerHandler): base(innerHandler)
         {
             this.options = options;
-            this.options.SignVersions = options.SignVersions ?? new List<MAuthVersion> { MAuthVersion.MWSV2 };
+            this.options.SignVersions = options.SignVersions ?? MAuthVersion.MWSV2;
         }
 
         /// <summary>
@@ -57,10 +56,13 @@ namespace Medidata.MAuth.Core
             if (InnerHandler == null)
                 InnerHandler = new HttpClientHandler();
 
-            foreach (var version in options.SignVersions)
+            foreach (MAuthVersion version in Enum.GetValues(typeof(MAuthVersion)))
             {
-                var mAuthCore = MAuthCoreFactory.Instantiate(version);
-                request = await mAuthCore.Sign(request, options).ConfigureAwait(false);
+                if (options.SignVersions.HasFlag(version))
+                {
+                    var mAuthCore = MAuthCoreFactory.Instantiate(version);
+                    request = await mAuthCore.Sign(request, options).ConfigureAwait(false);
+                }
             }
 
             return await base

--- a/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
+++ b/src/Medidata.MAuth.Core/MAuthSigningHandler.cs
@@ -58,8 +58,8 @@ namespace Medidata.MAuth.Core
             if (InnerHandler == null)
                 InnerHandler = new HttpClientHandler();
 
-            var signingVersions = GetSigningVersions(options.SignVersions);
-            foreach(var version in signingVersions)
+            var mauthVersions = GetMAuthSigningVersions(options.SignVersions);
+            foreach(var version in mauthVersions)
             {
                 var mAuthCore = MAuthCoreFactory.Instantiate(version);
                 request = await mAuthCore.Sign(request, options).ConfigureAwait(false);
@@ -70,30 +70,30 @@ namespace Medidata.MAuth.Core
                 .ConfigureAwait(continueOnCapturedContext: false);
         }
 
-        private IEnumerable<MAuthVersion> GetSigningVersions(string signingOptions)
+        private IEnumerable<MAuthVersion> GetMAuthSigningVersions(string signingVersions)
         {
-            if (string.IsNullOrEmpty(signingOptions))
+            if (string.IsNullOrEmpty(signingVersions))
                 return new List<MAuthVersion>() { MAuthVersion.MWSV2 };
 
-            var signVersions = new List<MAuthVersion>();
-            var signingArray = signingOptions.ToLower().Split(',');
+            var mauthVersions = new List<MAuthVersion>();
+            var signingArray = signingVersions.ToLower().Split(',');
             foreach(var item in signingArray)
             {
                 switch (item.Trim())
                 {
                     case "v1":
-                        signVersions.Add(MAuthVersion.MWS);
+                        mauthVersions.Add(MAuthVersion.MWS);
                         break;
                     case "v2":
-                        signVersions.Add(MAuthVersion.MWSV2);
+                        mauthVersions.Add(MAuthVersion.MWSV2);
                         break;
                 }
             }
 
-            if(signingArray.Any() && !signVersions.Any())
-                throw new InvalidVersionException($"Signing with {signingOptions} version is not allowed.");
+            if(signingArray.Any() && !mauthVersions.Any())
+                throw new InvalidVersionException($"Signing with {signingVersions} version is not allowed.");
 
-            return signVersions;
+            return mauthVersions;
         }
     }
 }

--- a/src/Medidata.MAuth.Core/Models/MAuthVersion.cs
+++ b/src/Medidata.MAuth.Core/Models/MAuthVersion.cs
@@ -8,11 +8,11 @@
         /// <summary>
         /// Defines the enumeration value for V1 protocol.
         /// </summary>
-        MWS,
+        MWS = 1,
 
         /// <summary>
         /// Defines the enumeration value for V2 protocol.
         /// </summary>
-        MWSV2
+        MWSV2 = 2
     }
 }

--- a/src/Medidata.MAuth.Core/Models/MAuthVersion.cs
+++ b/src/Medidata.MAuth.Core/Models/MAuthVersion.cs
@@ -1,8 +1,11 @@
-﻿namespace Medidata.MAuth.Core.Models
+﻿using System;
+
+namespace Medidata.MAuth.Core.Models
 {
     /// <summary>
     /// Contains the Enumeration values for different versions supported by the library.
     /// </summary>
+    [Flags]
     public enum MAuthVersion
     {
         /// <summary>

--- a/src/Medidata.MAuth.Core/Options/MAuthSigningOptions.cs
+++ b/src/Medidata.MAuth.Core/Options/MAuthSigningOptions.cs
@@ -24,6 +24,6 @@ namespace Medidata.MAuth.Core
         /// <summary>
         /// Comma-separated protocol versions to sign requests, if not provided defaults to "v2".
         /// </summary>
-        public string SigningOptions { get; set; }
+        public string SignVersions { get; set; }
     }
 }

--- a/src/Medidata.MAuth.Core/Options/MAuthSigningOptions.cs
+++ b/src/Medidata.MAuth.Core/Options/MAuthSigningOptions.cs
@@ -26,6 +26,6 @@ namespace Medidata.MAuth.Core
         /// <summary>
         /// Enumeration values of MAuth protocol versions to sign requests, if not provided defaults to `MWSV2`.
         /// </summary>
-        public Enum SignVersions { get; set; }
+        public MAuthVersion SignVersions { get; set; } = MAuthVersion.MWSV2;
     }
 }

--- a/src/Medidata.MAuth.Core/Options/MAuthSigningOptions.cs
+++ b/src/Medidata.MAuth.Core/Options/MAuthSigningOptions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Medidata.MAuth.Core.Models;
+using System;
+using System.Collections.Generic;
 
 namespace Medidata.MAuth.Core
 {
@@ -22,8 +24,8 @@ namespace Medidata.MAuth.Core
         internal DateTimeOffset? SignedTime { get; set; }
 
         /// <summary>
-        /// Comma-separated protocol versions to sign requests, if not provided defaults to "v2".
+        /// Enumeration of MAuth protocol versions to sign requests, if not provided defaults to "v2".
         /// </summary>
-        public string SignVersions { get; set; }
+        public IEnumerable<MAuthVersion> SignVersions { get; set; }
     }
 }

--- a/src/Medidata.MAuth.Core/Options/MAuthSigningOptions.cs
+++ b/src/Medidata.MAuth.Core/Options/MAuthSigningOptions.cs
@@ -24,8 +24,8 @@ namespace Medidata.MAuth.Core
         internal DateTimeOffset? SignedTime { get; set; }
 
         /// <summary>
-        /// Enumeration of MAuth protocol versions to sign requests, if not provided defaults to "v2".
+        /// Enumeration values of MAuth protocol versions to sign requests, if not provided defaults to `MWSV2`.
         /// </summary>
-        public IEnumerable<MAuthVersion> SignVersions { get; set; }
+        public Enum SignVersions { get; set; }
     }
 }

--- a/src/Medidata.MAuth.Core/Options/MAuthSigningOptions.cs
+++ b/src/Medidata.MAuth.Core/Options/MAuthSigningOptions.cs
@@ -24,8 +24,8 @@ namespace Medidata.MAuth.Core
         internal DateTimeOffset? SignedTime { get; set; }
 
         /// <summary>
-        /// Enumeration values of MAuth protocol versions to sign requests, if not provided defaults to `MWSV2`.
+        /// Enumeration values of MAuth protocol versions to sign requests, if not provided defaults to `MWS`.
         /// </summary>
-        public MAuthVersion SignVersions { get; set; } = MAuthVersion.MWSV2;
+        public MAuthVersion SignVersions { get; set; } = MAuthVersion.MWS;
     }
 }

--- a/src/Medidata.MAuth.Core/Options/MAuthSigningOptions.cs
+++ b/src/Medidata.MAuth.Core/Options/MAuthSigningOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Medidata.MAuth.Core.Models;
 
 namespace Medidata.MAuth.Core
 {
@@ -23,8 +22,8 @@ namespace Medidata.MAuth.Core
         internal DateTimeOffset? SignedTime { get; set; }
 
         /// <summary>
-        /// Determines the boolean value if V1 option of signing should be disabled or not with default value of false.
+        /// Comma-separated protocol versions to sign requests, if not provided defaults to "v2".
         /// </summary>
-        public bool DisableV1 { get; set; } = false;
+        public string SigningOptions { get; set; }
     }
 }

--- a/tests/Medidata.MAuth.Tests/MAuthSigningHandlerTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthSigningHandlerTests.cs
@@ -49,7 +49,7 @@ namespace Medidata.MAuth.Tests
             var actual = new AssertSigningHandler();
             var clientOptions = TestExtensions.ClientOptions(testData.SignedTime);
             var version = MAuthVersion.MWS;
-            clientOptions.SignVersions = new List<MAuthVersion> { version };
+            clientOptions.SignVersions = version;
             var signingHandler = new MAuthSigningHandler(clientOptions, actual);
 
             // Act
@@ -77,7 +77,8 @@ namespace Medidata.MAuth.Tests
             var testData = await method.FromResourceV2();
             var actual = new AssertSigningHandler();
             var clientOptions = TestExtensions.ClientOptions(testData.SignedTime);
-            clientOptions.SignVersions = new List<MAuthVersion> { MAuthVersion.MWS, MAuthVersion.MWSV2 };
+            clientOptions.SignVersions = MAuthVersion.MWS | MAuthVersion.MWSV2;
+
             var signingHandler = new MAuthSigningHandler(clientOptions, actual);
 
             // Act

--- a/tests/Medidata.MAuth.Tests/MAuthSigningHandlerTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthSigningHandlerTests.cs
@@ -48,7 +48,7 @@ namespace Medidata.MAuth.Tests
             var testData = await method.FromResourceV2();
             var actual = new AssertSigningHandler();
             var clientOptions = TestExtensions.ClientOptions(testData.SignedTime);
-            clientOptions.SigningOptions = "v1";
+            clientOptions.SignVersions = "v1";
             var version = MAuthVersion.MWS;
             var signingHandler = new MAuthSigningHandler(clientOptions, actual);
 
@@ -77,7 +77,7 @@ namespace Medidata.MAuth.Tests
             var testData = await method.FromResourceV2();
             var actual = new AssertSigningHandler();
             var clientOptions = TestExtensions.ClientOptions(testData.SignedTime);
-            clientOptions.SigningOptions = "v1,v2";
+            clientOptions.SignVersions = "v1,v2";
             var signingHandler = new MAuthSigningHandler(clientOptions, actual);
 
             // Act
@@ -105,7 +105,7 @@ namespace Medidata.MAuth.Tests
             var testData = await method.FromResourceV2();
             var actual = new AssertSigningHandler();
             var clientOptions = TestExtensions.ClientOptions(testData.SignedTime);
-            clientOptions.SigningOptions = "v12";
+            clientOptions.SignVersions = "v12";
             var signingHandler = new MAuthSigningHandler(clientOptions, actual);
 
             // Act
@@ -115,7 +115,7 @@ namespace Medidata.MAuth.Tests
                 var exception = await Assert.ThrowsAsync<InvalidVersionException>(() 
                     => client.SendAsync(testData.ToDefaultHttpRequestMessage()));
                 Assert.Equal(exception.Message, 
-                    $"Signing with {clientOptions.SigningOptions} version is not allowed.");
+                    $"Signing with {clientOptions.SignVersions} version is not allowed.");
             }
         }
     }

--- a/tests/Medidata.MAuth.Tests/MAuthSigningHandlerTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthSigningHandlerTests.cs
@@ -15,12 +15,12 @@ namespace Medidata.MAuth.Tests
         [InlineData("DELETE")]
         [InlineData("POST")]
         [InlineData("PUT")]
-        public static async Task SendAsync_WithNoSignVersions_WillSignWithOnlyMWSV2(string method)
+        public static async Task SendAsync_WithNoSignVersions_WillSignWithOnlyMWS(string method)
         {
             // Arrange
             var testData = await method.FromResource();
             var actual = new AssertSigningHandler();
-            var version = MAuthVersion.MWSV2;
+            var version = MAuthVersion.MWS;
             var signingHandler = new MAuthSigningHandler(TestExtensions.ClientOptions(testData.SignedTime), actual);
 
             // Act
@@ -30,11 +30,11 @@ namespace Medidata.MAuth.Tests
             }
 
             // Assert
-            Assert.Null(actual.MAuthHeader);
-            Assert.Null(actual.MAuthTimeHeader);
+            Assert.Null(actual.MAuthHeaderV2);
+            Assert.Null(actual.MAuthTimeHeaderV2);
 
-            Assert.Equal(testData.MAuthHeaderV2, actual.MAuthHeaderV2);
-            Assert.Equal(testData.SignedTime, long.Parse(actual.MAuthTimeHeaderV2).FromUnixTimeSeconds());
+            Assert.Equal(testData.MAuthHeader, actual.MAuthHeader);
+            Assert.Equal(testData.SignedTime, long.Parse(actual.MAuthTimeHeader).FromUnixTimeSeconds());
         }
 
         [Theory]

--- a/tests/Medidata.MAuth.Tests/MAuthSigningHandlerTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthSigningHandlerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
 using Medidata.MAuth.Core;
+using Medidata.MAuth.Core.Exceptions;
 using Medidata.MAuth.Core.Models;
 using Medidata.MAuth.Tests.Infrastructure;
 using Xunit;
@@ -14,12 +15,70 @@ namespace Medidata.MAuth.Tests
         [InlineData("DELETE")]
         [InlineData("POST")]
         [InlineData("PUT")]
-        public static async Task SendAsync_WithDefault_WillSignProperly_BothMWSAndMWSV2(string method)
+        public static async Task SendAsync_WithNoSigningOptions_WillSignWithOnlyMWSV2(string method)
         {
             // Arrange
             var testData = await method.FromResource();
             var actual = new AssertSigningHandler();
+            var version = MAuthVersion.MWSV2;
             var signingHandler = new MAuthSigningHandler(TestExtensions.ClientOptions(testData.SignedTime), actual);
+
+            // Act
+            using (var client = new HttpClient(signingHandler))
+            {
+                await client.SendAsync(testData.ToHttpRequestMessage(version));
+            }
+
+            // Assert
+            Assert.Null(actual.MAuthHeader);
+            Assert.Null(actual.MAuthTimeHeader);
+
+            Assert.Equal(testData.MAuthHeaderV2, actual.MAuthHeaderV2);
+            Assert.Equal(testData.SignedTime, long.Parse(actual.MAuthTimeHeaderV2).FromUnixTimeSeconds());
+        }
+
+        [Theory]
+        [InlineData("GET")]
+        [InlineData("DELETE")]
+        [InlineData("POST")]
+        [InlineData("PUT")]
+        public static async Task SendAsync_WithSigningOptionsV1_WillSignWithMWS(string method)
+        {
+            // Arrange
+            var testData = await method.FromResourceV2();
+            var actual = new AssertSigningHandler();
+            var clientOptions = TestExtensions.ClientOptions(testData.SignedTime);
+            clientOptions.SigningOptions = "v1";
+            var version = MAuthVersion.MWS;
+            var signingHandler = new MAuthSigningHandler(clientOptions, actual);
+
+            // Act
+            using (var client = new HttpClient(signingHandler))
+            {
+                await client.SendAsync(testData.ToHttpRequestMessage(version));
+            }
+
+            // Assert
+            Assert.Equal(testData.MAuthHeader, actual.MAuthHeader);
+            Assert.Equal(testData.SignedTime, long.Parse(actual.MAuthTimeHeader).FromUnixTimeSeconds());
+
+            Assert.Null(actual.MAuthHeaderV2);
+            Assert.Null(actual.MAuthTimeHeaderV2);
+        }
+
+        [Theory]
+        [InlineData("GET")]
+        [InlineData("DELETE")]
+        [InlineData("POST")]
+        [InlineData("PUT")]
+        public static async Task SendAsync_WithSigningOptionsV1AndV2_WillSignWithBothMWSAndMWSV2(string method)
+        {
+            // Arrange
+            var testData = await method.FromResourceV2();
+            var actual = new AssertSigningHandler();
+            var clientOptions = TestExtensions.ClientOptions(testData.SignedTime);
+            clientOptions.SigningOptions = "v1,v2";
+            var signingHandler = new MAuthSigningHandler(clientOptions, actual);
 
             // Act
             using (var client = new HttpClient(signingHandler))
@@ -32,7 +91,7 @@ namespace Medidata.MAuth.Tests
             Assert.Equal(testData.SignedTime, long.Parse(actual.MAuthTimeHeader).FromUnixTimeSeconds());
 
             Assert.Equal(testData.MAuthHeaderV2, actual.MAuthHeaderV2);
-            Assert.Equal(testData.SignedTime, long.Parse(actual.MAuthTimeHeader).FromUnixTimeSeconds());
+            Assert.Equal(testData.SignedTime, long.Parse(actual.MAuthTimeHeaderV2).FromUnixTimeSeconds());
         }
 
         [Theory]
@@ -40,26 +99,24 @@ namespace Medidata.MAuth.Tests
         [InlineData("DELETE")]
         [InlineData("POST")]
         [InlineData("PUT")]
-        public static async Task SendAsync_WithDisableV1_WillSignProperlyWithMWSV2(string method)
+        public static async Task SendAsync_WithImproperSigningOptions_WillThrowException(string method)
         {
             // Arrange
             var testData = await method.FromResourceV2();
             var actual = new AssertSigningHandler();
-            var version = MAuthVersion.MWSV2;
             var clientOptions = TestExtensions.ClientOptions(testData.SignedTime);
-            clientOptions.DisableV1 = true;
+            clientOptions.SigningOptions = "v12";
             var signingHandler = new MAuthSigningHandler(clientOptions, actual);
 
-
             // Act
+            // Assert
             using (var client = new HttpClient(signingHandler))
             {
-                await client.SendAsync(testData.ToHttpRequestMessage(version));
+                var exception = await Assert.ThrowsAsync<InvalidVersionException>(() 
+                    => client.SendAsync(testData.ToDefaultHttpRequestMessage()));
+                Assert.Equal(exception.Message, 
+                    $"Signing with {clientOptions.SigningOptions} version is not allowed.");
             }
-
-            // Assert
-            Assert.Equal(testData.MAuthHeaderV2, actual.MAuthHeaderV2);
-            Assert.Equal(testData.SignedTime, long.Parse(actual.MAuthTimeHeaderV2).FromUnixTimeSeconds());
         }
     }
 }

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>4.1.0</Version>
+    <Version>5.0.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR is for this story:https://jira.mdsol.com/browse/MCC-638046

It includes:

- Replace `DisableV1` option in Signing with `SigningOptions` parameter which enumerations of protocol versions
as `SignVersions = MAuthVersion.MWS | MAuthVersion.MWSV2`
- Defaults the signing to `MWSV2` when `SignVersions` is not provided.
- Updated `CHANGELOG` and `README`.

Notes: Since not all apps are updated to latest, please use v1 when you experience authentication failures.
Relevant PR from:
Ruby: https://github.com/mdsol/mauth-client-ruby/pull/40
Python: https://github.com/mdsol/mauth-client-python/pull/19
Java: https://github.com/mdsol/mauth-jvm-clients/pull/128

Please review:
@mdsol/architecture-enablement 
@mdsol/libraries_dotnet 
@mdsol/team-51 
