### PR TITLE
[MCC-575820] Incorporate protocol test suite and implement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
  - **[Core]** Added normalization of Uri AbsolutePath.
  - **[Core]** Added unescape step in query_string encoding to remove `double encoding`.
  - **[Core]** Replace `DisableV1`option with `SignVersions` option and change the default signing to `MAuthVersion.MWS` only.
+ - **[Core]** Added parsing code to test with mauth-protocol-test-suite.
+ - **[Core]** Fixed bug in sorting of query parameters.
 
 ## v4.0.2
 - **[AspNetCore]** Update aspnetcore version to aspnetcore2.1 LTS.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ To run tests, go the folder `mauth-client-dotnet\tests\Medidata.MAuth.Tests`
 Next, run the tests as:
 
 ```
-dotnet test
+dotnet xunit -notrait "Category=ProtocolTestSuite"
 ```
 
 ## Running mauth-protocol-test-suite
@@ -21,5 +21,5 @@ Then navigate to :`mauth-client-dotnet\tests\Medidata.MAuth.Tests`
 And, run the tests as:
 
 ```
-dotnet test --filter "FullyQualifiedName~MAuthProtocolSuiteTests"
+dotnet xunit -trait "Category=ProtocolTestSuite"
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing
+
+## General Information
+* Clone this repo in your workspace. Checkout latest `develop` branch.
+* Make new changes or updates into `feature/bugfix` branch.
+* Make sure to add unit tests for it so that there is no breaking changes.
+* Commit and push your branch to compare and create PR against latest `develop` branch.
+
+## Running Tests
+To run tests, go the folder `mauth-client-dotnet\tests\Medidata.MAuth.Tests`
+Next, run the tests as:
+
+```
+dotnet test
+```
+
+## Running mauth-protocol-test-suite
+To run the mauth-protocol-test-suite clone the latest suite onto your machine and place it in the same parent directory as this repo (or supply the ENV var 
+`TEST_SUITE_PATH` with the path to the test suite relative to this repo).  
+Then navigate to :`mauth-client-dotnet\tests\Medidata.MAuth.Tests`  
+And, run the tests as:
+
+```
+dotnet test --filter "FullyQualifiedName~MAuthProtocolSuiteTests"
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ To run tests, go the folder `mauth-client-dotnet\tests\Medidata.MAuth.Tests`
 Next, run the tests as:
 
 ```
-dotnet xunit -notrait "Category=ProtocolTestSuite"
+dotnet test --filter "Category!=ProtocolTestSuite"
 ```
 
 ## Running mauth-protocol-test-suite
@@ -21,5 +21,5 @@ Then navigate to :`mauth-client-dotnet\tests\Medidata.MAuth.Tests`
 And, run the tests as:
 
 ```
-dotnet xunit -trait "Category=ProtocolTestSuite"
+dotnet test --filter "Category=ProtocolTestSuite"
 ```

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -67,7 +67,7 @@ Write-Host "Running unit tests..." -ForegroundColor Cyan
 
 Push-Location -Path .\tests\Medidata.MAuth.Tests
 
-dotnet test
+dotnet test --filter "Category!=ProtocolTestSuite"
 
 Pop-Location
 

--- a/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
+++ b/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
@@ -188,33 +188,27 @@ namespace Medidata.MAuth.Core
                 return string.Empty;
 
             var queryArray = queryString.Split('&');
+            var unescapedKeysAndValues = new KeyValuePair<string, string>[queryArray.Count()];
 
             // unescaping
             for (int i = 0; i < queryArray.Length; i++)
             {
                 var keyValue = queryArray[i].Split('=');
-                var unEscapedKey = Uri.UnescapeDataString(keyValue[0]);
-                var unEscapedValue = Uri.UnescapeDataString(keyValue[1]);
-                queryArray[i] = $"{unEscapedKey}={unEscapedValue}";
+                unescapedKeysAndValues[i] = new KeyValuePair<string, string>(
+                    Uri.UnescapeDataString(keyValue[0]), Uri.UnescapeDataString(keyValue[1]));
             }
 
-            // sorting
-            Array.Sort(queryArray, StringComparer.Ordinal);
-
-            // escaping
-            for (int i = 0; i < queryArray.Length; i++)
-            {
-                var keyValue = queryArray[i].Split('=');
-                var escapedKey = Uri.EscapeDataString(keyValue[0]);
-                var escapedValue = Uri.EscapeDataString(keyValue[1]);
-                queryArray[i] = $"{escapedKey}={escapedValue}";
-            }
+            // sorting and escaping
+            var escapedKeyValues = unescapedKeysAndValues
+                .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                .ThenBy(kv => kv.Value, StringComparer.Ordinal)
+                .Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value)}");
 
             // Above encoding converts space as `%20` and `+` as `%2B`
             // But space and `+` both needs to be converted as `%20` as per
             // reference https://github.com/mdsol/mauth-client-ruby/blob/v6.0.0/lib/mauth/request_and_response.rb#L113
             // so this convert `%2B` into `%20` to match encodedqueryparams to that of other languages.
-            return string.Join("&", queryArray).Replace("%2B", "%20");
+            return string.Join("&", escapedKeyValues).Replace("%2B", "%20");
         }
 
         /// <summary>

--- a/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
+++ b/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
@@ -188,7 +188,7 @@ namespace Medidata.MAuth.Core
                 return string.Empty;
 
             var queryArray = queryString.Split('&');
-            var unescapedKeysAndValues = new KeyValuePair<string, string>[queryArray.Count()];
+            var unescapedKeysAndValues = new KeyValuePair<string, string>[queryArray.Length];
 
             // unescaping
             for (int i = 0; i < queryArray.Length; i++)

--- a/tests/Medidata.MAuth.Tests/Infrastructure/AssertSigningHandler.cs
+++ b/tests/Medidata.MAuth.Tests/Infrastructure/AssertSigningHandler.cs
@@ -29,7 +29,7 @@ namespace Medidata.MAuth.Tests.Infrastructure
             MAuthTimeHeaderV2 = request.Headers.GetFirstValueOrDefault<string>(Constants.MAuthTimeHeaderKeyV2);
             MAuthTimeHeader = request.Headers.GetFirstValueOrDefault<string>(Constants.MAuthTimeHeaderKey);
 
-            return Task.Run(() => new HttpResponseMessage(HttpStatusCode.OK));
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
         }
     }
 }

--- a/tests/Medidata.MAuth.Tests/Infrastructure/MAuthServerHandler.cs
+++ b/tests/Medidata.MAuth.Tests/Infrastructure/MAuthServerHandler.cs
@@ -62,8 +62,7 @@ namespace Medidata.MAuth.Tests.Infrastructure
                             Uuid = isProtocolSuiteTest ? SigningAppUuid : clientUuid,
                             Name = "Medidata.MAuth.Tests",
                             CreationDate = new DateTimeOffset(2016, 8, 1, 0, 0, 0, TimeSpan.Zero),
-                            PublicKey = isProtocolSuiteTest 
-                            ? SigningPublicKey : TestExtensions.ClientPublicKey
+                            PublicKey = isProtocolSuiteTest ? SigningPublicKey : TestExtensions.ClientPublicKey
                         }
                     })
                 )

--- a/tests/Medidata.MAuth.Tests/Infrastructure/MAuthServerHandler.cs
+++ b/tests/Medidata.MAuth.Tests/Infrastructure/MAuthServerHandler.cs
@@ -11,6 +11,8 @@ namespace Medidata.MAuth.Tests.Infrastructure
 {
     internal class MAuthServerHandler : HttpMessageHandler
     {
+        private MAuthServerHandler() { }
+
         private static readonly Guid _clientUuid = new Guid("192cce84-8466-490e-b03e-074f82da3ee2");
         private int _currentNumberOfAttempts = 0;
 
@@ -19,12 +21,18 @@ namespace Medidata.MAuth.Tests.Infrastructure
         private static string _signingPublicKey;
         private static Guid _signingAppUuid;
 
-        public async Task<MAuthServerHandler> InitializeAsync()
+        private async Task<MAuthServerHandler> InitializeAsync()
         {
             var protocolSuite = new ProtocolTestSuiteHelper();
             _signingPublicKey = await protocolSuite.GetPublicKey();
             _signingAppUuid = await protocolSuite.ReadSignInAppUuid();
             return this;
+        }
+
+        public static Task<MAuthServerHandler> CreateAsync()
+        {
+            var ret = new MAuthServerHandler();
+            return ret.InitializeAsync();
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(

--- a/tests/Medidata.MAuth.Tests/Infrastructure/TestExtensions.cs
+++ b/tests/Medidata.MAuth.Tests/Infrastructure/TestExtensions.cs
@@ -20,13 +20,13 @@ namespace Medidata.MAuth.Tests.Infrastructure
         public static readonly string ServerPrivateKey = GetKeyFromResource(nameof(ServerPrivateKey)).Result;
         public static readonly string ServerPublicKey = GetKeyFromResource(nameof(ServerPublicKey)).Result;
 
-        public static MAuthOptionsBase ServerOptions => new MAuthTestOptions()
+        public static MAuthOptionsBase ServerOptions(MAuthServerHandler serverHandler) => new MAuthTestOptions()
         {
             ApplicationUuid = ServerUuid,
             MAuthServiceUrl = TestUri,
             PrivateKey = ServerPrivateKey,
             MAuthServiceRetryPolicy = MAuthServiceRetryPolicy.RetryOnce,
-            MAuthServerHandler = new MAuthServerHandler()
+            MAuthServerHandler = serverHandler
         };
 
         public static MAuthSigningOptions ClientOptions(DateTimeOffset signedTime) => new MAuthSigningOptions()
@@ -37,18 +37,18 @@ namespace Medidata.MAuth.Tests.Infrastructure
         };
 
         public static MAuthOptionsBase GetServerOptionsWithAttempts(MAuthServiceRetryPolicy policy,
-            bool shouldSucceedWithin) =>
-            new MAuthTestOptions()
+            bool shouldSucceedWithin, MAuthServerHandler serverHandler)
+        {
+            serverHandler.SucceedAfterThisManyAttempts = (int)policy + (shouldSucceedWithin ? 1 : 2);
+            return new MAuthTestOptions()
             {
                 ApplicationUuid = ServerUuid,
                 MAuthServiceUrl = TestUri,
                 PrivateKey = ServerPrivateKey,
                 MAuthServiceRetryPolicy = policy,
-                MAuthServerHandler = new MAuthServerHandler()
-                {
-                    SucceedAfterThisManyAttempts = (int)policy + (shouldSucceedWithin ? 1 : 2)
-                }
+                MAuthServerHandler = serverHandler
             };
+        }
 
         public static Task<string> GetStringFromResource(string resourceName)
         {

--- a/tests/Medidata.MAuth.Tests/Infrastructure/TestExtensions.cs
+++ b/tests/Medidata.MAuth.Tests/Infrastructure/TestExtensions.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Medidata.MAuth.Core;
 using Newtonsoft.Json;
 using Medidata.MAuth.Core.Models;
-using Medidata.MAuth.Tests.ProtocolTestSuite;
 
 namespace Medidata.MAuth.Tests.Infrastructure
 {
@@ -124,23 +123,5 @@ namespace Medidata.MAuth.Tests.Infrastructure
 
         public static HttpMethod ToHttpMethod(this string method) => new HttpMethod(method);
 
-        public static MAuthSigningOptions ProtocolTestClientOptions(Guid clientUuid, 
-            string clientPrivateKey, DateTimeOffset signedTime) => new MAuthSigningOptions()
-        {
-            ApplicationUuid = clientUuid,
-            PrivateKey = clientPrivateKey,
-            SignedTime = signedTime
-        };
-
-        public static HttpRequestMessage ToHttpRequestMessage(this UnSignedRequest data)
-        {
-            var result = new HttpRequestMessage(new HttpMethod(data.Verb), new Uri($"https://example.com{data.Url}"))
-            {
-                Content = !string.IsNullOrEmpty(data.Body) 
-                    ? new ByteArrayContent(Convert.FromBase64String(data.Body)) : null,
-            };
-
-            return result;
-        }
     }
 }

--- a/tests/Medidata.MAuth.Tests/Infrastructure/TestExtensions.cs
+++ b/tests/Medidata.MAuth.Tests/Infrastructure/TestExtensions.cs
@@ -137,7 +137,7 @@ namespace Medidata.MAuth.Tests.Infrastructure
             var result = new HttpRequestMessage(new HttpMethod(data.Verb), new Uri($"https://example.com{data.Url}"))
             {
                 Content = !string.IsNullOrEmpty(data.Body) 
-                ? new ByteArrayContent(Convert.FromBase64String(data.Body)) : null,
+                    ? new ByteArrayContent(Convert.FromBase64String(data.Body)) : null,
             };
 
             return result;

--- a/tests/Medidata.MAuth.Tests/Infrastructure/TestExtensions.cs
+++ b/tests/Medidata.MAuth.Tests/Infrastructure/TestExtensions.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Medidata.MAuth.Core;
 using Newtonsoft.Json;
 using Medidata.MAuth.Core.Models;
+using Medidata.MAuth.Tests.ProtocolTestSuite;
 
 namespace Medidata.MAuth.Tests.Infrastructure
 {
@@ -123,5 +124,23 @@ namespace Medidata.MAuth.Tests.Infrastructure
 
         public static HttpMethod ToHttpMethod(this string method) => new HttpMethod(method);
 
+        public static MAuthSigningOptions ProtocolTestClientOptions(Guid clientUuid, 
+            string clientPrivateKey, DateTimeOffset signedTime) => new MAuthSigningOptions()
+        {
+            ApplicationUuid = clientUuid,
+            PrivateKey = clientPrivateKey,
+            SignedTime = signedTime
+        };
+
+        public static HttpRequestMessage ToHttpRequestMessage(this UnSignedRequest data)
+        {
+            var result = new HttpRequestMessage(new HttpMethod(data.Verb), new Uri($"https://example.com{data.Url}"))
+            {
+                Content = !string.IsNullOrEmpty(data.Body) 
+                ? new ByteArrayContent(Convert.FromBase64String(data.Body)) : null,
+            };
+
+            return result;
+        }
     }
 }

--- a/tests/Medidata.MAuth.Tests/MAuthAspNetCoreTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthAspNetCoreTests.cs
@@ -23,6 +23,7 @@ namespace Medidata.MAuth.Tests
         {
             // Arrange
             var testData = await method.FromResourceV2();
+            var serverHandler = await MAuthServerHandler.CreateAsync();
 
             using (var server = new TestServer(new WebHostBuilder().Configure(app =>
             {
@@ -31,7 +32,7 @@ namespace Medidata.MAuth.Tests
                     options.ApplicationUuid = TestExtensions.ServerUuid;
                     options.MAuthServiceUrl = TestExtensions.TestUri;
                     options.PrivateKey = TestExtensions.ServerPrivateKey;
-                    options.MAuthServerHandler = new MAuthServerHandler();
+                    options.MAuthServerHandler = serverHandler;
                     options.HideExceptionsAndReturnUnauthorized = false;
                 });
 
@@ -55,6 +56,7 @@ namespace Medidata.MAuth.Tests
         {
             // Arrange
             var testData = await method.FromResource();
+            var serverHandler = await MAuthServerHandler.CreateAsync();
 
             using (var server = new TestServer(new WebHostBuilder().Configure(app =>
             {
@@ -63,7 +65,7 @@ namespace Medidata.MAuth.Tests
                     options.ApplicationUuid = TestExtensions.ServerUuid;
                     options.MAuthServiceUrl = TestExtensions.TestUri;
                     options.PrivateKey = TestExtensions.ServerPrivateKey;
-                    options.MAuthServerHandler = new MAuthServerHandler();
+                    options.MAuthServerHandler = serverHandler;
                 });
 
                 app.Run(async context => await new StreamWriter(context.Response.Body).WriteAsync("Done."));
@@ -87,6 +89,7 @@ namespace Medidata.MAuth.Tests
         {
             // Arrange
             var testData = await method.FromResource();
+            var serverHandler = await MAuthServerHandler.CreateAsync();
 
             using (var server = new TestServer(new WebHostBuilder().Configure(app =>
             {
@@ -95,7 +98,7 @@ namespace Medidata.MAuth.Tests
                     options.ApplicationUuid = TestExtensions.ServerUuid;
                     options.MAuthServiceUrl = TestExtensions.TestUri;
                     options.PrivateKey = TestExtensions.ServerPrivateKey;
-                    options.MAuthServerHandler = new MAuthServerHandler();
+                    options.MAuthServerHandler = serverHandler;
                     options.HideExceptionsAndReturnUnauthorized = false;
                 });
             })))
@@ -121,6 +124,8 @@ namespace Medidata.MAuth.Tests
             var testData = await method.FromResourceV2();
             var canSeek = false;
             var body = string.Empty;
+            var serverHandler = await MAuthServerHandler.CreateAsync();
+
             using (var server = new TestServer(new WebHostBuilder().Configure(app =>
             {
                 app
@@ -130,7 +135,7 @@ namespace Medidata.MAuth.Tests
                         options.ApplicationUuid = TestExtensions.ServerUuid;
                         options.MAuthServiceUrl = TestExtensions.TestUri;
                         options.PrivateKey = TestExtensions.ServerPrivateKey;
-                        options.MAuthServerHandler = new MAuthServerHandler();
+                        options.MAuthServerHandler = serverHandler;
                     })
                     .Run(async context =>
                     {

--- a/tests/Medidata.MAuth.Tests/MAuthAuthenticatorTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthAuthenticatorTests.cs
@@ -44,7 +44,8 @@ namespace Medidata.MAuth.Tests
         {
             // Arrange
             var testData = await method.FromResource();
-            var authenticator = new MAuthAuthenticator(TestExtensions.ServerOptions, NullLogger<MAuthAuthenticator>.Instance);
+            var serverHandler = await MAuthServerHandler.CreateAsync();
+            var authenticator = new MAuthAuthenticator(TestExtensions.ServerOptions(serverHandler), NullLogger<MAuthAuthenticator>.Instance);
             var mAuthCore = new MAuthCore();
 
             var signedRequest = await mAuthCore
@@ -72,7 +73,8 @@ namespace Medidata.MAuth.Tests
             // Arrange
             var testData = await method.FromResourceV2();
             var version = MAuthVersion.MWSV2;
-            var authenticator = new MAuthAuthenticator(TestExtensions.ServerOptions, NullLogger<MAuthAuthenticator>.Instance);
+            var serverHandler = await MAuthServerHandler.CreateAsync();
+            var authenticator = new MAuthAuthenticator(TestExtensions.ServerOptions(serverHandler), NullLogger<MAuthAuthenticator>.Instance);
             var mAuthCore = new MAuthCoreV2();
 
             var signedRequest = await mAuthCore
@@ -101,9 +103,9 @@ namespace Medidata.MAuth.Tests
         {
             // Arrange
             var testData = await "GET".FromResourceV2();
-
+            var serverHandler = await MAuthServerHandler.CreateAsync();
             var authenticator = new MAuthAuthenticator(TestExtensions.GetServerOptionsWithAttempts(
-                policy, shouldSucceedWithin: true), NullLogger<MAuthAuthenticator>.Instance);
+                policy, shouldSucceedWithin: true, serverHandler), NullLogger<MAuthAuthenticator>.Instance);
             var mAuthCore = new MAuthCoreV2();
 
             var signedRequest = await mAuthCore
@@ -132,8 +134,9 @@ namespace Medidata.MAuth.Tests
             // Arrange
             var testData = await "GET".FromResourceV2();
             var version = MAuthVersion.MWSV2;
+            var serverHandler = await MAuthServerHandler.CreateAsync();
             var authenticator = new MAuthAuthenticator(TestExtensions.GetServerOptionsWithAttempts(
-                policy, shouldSucceedWithin: true), NullLogger<MAuthAuthenticator>.Instance);
+                policy, shouldSucceedWithin: true, serverHandler), NullLogger<MAuthAuthenticator>.Instance);
             var mAuthCore = new MAuthCoreV2();
 
             var signedRequest = await mAuthCore
@@ -161,9 +164,9 @@ namespace Medidata.MAuth.Tests
         {
             // Arrange
             var testData = await "GET".FromResource();
-
+            var serverHandler = await MAuthServerHandler.CreateAsync();
             var authenticator = new MAuthAuthenticator(TestExtensions.GetServerOptionsWithAttempts(
-                policy, shouldSucceedWithin: false), NullLogger<MAuthAuthenticator>.Instance);
+                policy, shouldSucceedWithin: false, serverHandler), NullLogger<MAuthAuthenticator>.Instance);
             var mAuthCore = new MAuthCore();
 
             var signedRequest = await mAuthCore
@@ -197,8 +200,10 @@ namespace Medidata.MAuth.Tests
             // Arrange
             var testData = await "GET".FromResource();
             var version = MAuthVersion.MWSV2;
+            var serverHandler = await MAuthServerHandler.CreateAsync();
+
             var authenticator = new MAuthAuthenticator(TestExtensions.GetServerOptionsWithAttempts(
-                policy, shouldSucceedWithin: false), NullLogger<MAuthAuthenticator>.Instance);
+                policy, shouldSucceedWithin: false, serverHandler), NullLogger<MAuthAuthenticator>.Instance);
             var mAuthCore = new MAuthCoreV2();
 
             var signedRequest = await mAuthCore
@@ -278,7 +283,7 @@ namespace Medidata.MAuth.Tests
         {
             // Arrange
             var testData = await method.FromResource();
-            var testOptions = TestExtensions.ServerOptions;
+            var testOptions = TestExtensions.ServerOptions(await MAuthServerHandler.CreateAsync());
             testOptions.DisableV1 = true;
             var authenticator = new MAuthAuthenticator(testOptions, NullLogger<MAuthAuthenticator>.Instance);
             var mAuthCore = new MAuthCore();
@@ -310,7 +315,7 @@ namespace Medidata.MAuth.Tests
             // Arrange
             var testData = await method.FromResourceV2();
             var version = MAuthVersion.MWSV2;
-            var testOptions = TestExtensions.ServerOptions;
+            var testOptions = TestExtensions.ServerOptions(await MAuthServerHandler.CreateAsync());
             var mAuthCore = MAuthCoreFactory.Instantiate(version);
 
             // Act
@@ -332,7 +337,7 @@ namespace Medidata.MAuth.Tests
             // Arrange
             var testData = await method.FromResource();
             var version = MAuthVersion.MWS;
-            var testOptions = TestExtensions.ServerOptions;
+            var testOptions = TestExtensions.ServerOptions(await MAuthServerHandler.CreateAsync());
             var mAuthCore = MAuthCoreFactory.Instantiate(version);
 
             // Act
@@ -350,8 +355,8 @@ namespace Medidata.MAuth.Tests
             // Arrange
             var testData = await "GET".FromResource();
             var mockLogger = new Mock<ILogger>();
-
-            var authenticator = new MAuthAuthenticator(TestExtensions.ServerOptions, mockLogger.Object);
+            var serverHandler = await MAuthServerHandler.CreateAsync();
+            var authenticator = new MAuthAuthenticator(TestExtensions.ServerOptions(serverHandler), mockLogger.Object);
             var requestData = testData.ToDefaultHttpRequestMessage();
 
             // Act
@@ -373,7 +378,7 @@ namespace Medidata.MAuth.Tests
             // Arrange
             var testData = await "GET".FromResource();
             var mockLogger = new Mock<ILogger>();
-            var testOptions = TestExtensions.ServerOptions;
+            var testOptions = TestExtensions.ServerOptions(await MAuthServerHandler.CreateAsync());
             testOptions.DisableV1 = true;
 
             var authenticator = new MAuthAuthenticator(testOptions, mockLogger.Object);

--- a/tests/Medidata.MAuth.Tests/MAuthOwinTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthOwinTests.cs
@@ -23,6 +23,7 @@ namespace Medidata.MAuth.Tests
         {
             // Arrange
             var testData = await method.FromResourceV2();
+            var serverHandler = await MAuthServerHandler.CreateAsync();
 
             using (var server = TestServer.Create(app =>
             {
@@ -31,7 +32,7 @@ namespace Medidata.MAuth.Tests
                     options.ApplicationUuid = TestExtensions.ServerUuid;
                     options.MAuthServiceUrl = TestExtensions.TestUri;
                     options.PrivateKey = TestExtensions.ServerPrivateKey;
-                    options.MAuthServerHandler = new MAuthServerHandler();
+                    options.MAuthServerHandler = serverHandler;
                 });
 
                 app.Run(async context => await context.Response.WriteAsync("Done."));
@@ -54,6 +55,7 @@ namespace Medidata.MAuth.Tests
         {
             // Arrange
             var testData = await method.FromResource();
+            var serverHandler = await MAuthServerHandler.CreateAsync();
 
             using (var server = TestServer.Create(app =>
             {
@@ -62,7 +64,7 @@ namespace Medidata.MAuth.Tests
                     options.ApplicationUuid = TestExtensions.ServerUuid;
                     options.MAuthServiceUrl = TestExtensions.TestUri;
                     options.PrivateKey = TestExtensions.ServerPrivateKey;
-                    options.MAuthServerHandler = new MAuthServerHandler();
+                    options.MAuthServerHandler = serverHandler;
                 });
 
                 app.Run(async context => await context.Response.WriteAsync("Done."));
@@ -86,6 +88,7 @@ namespace Medidata.MAuth.Tests
         {
             // Arrange
             var testData = await method.FromResource();
+            var serverHandler = await MAuthServerHandler.CreateAsync();
 
             using (var server = TestServer.Create(app =>
             {
@@ -94,7 +97,7 @@ namespace Medidata.MAuth.Tests
                     options.ApplicationUuid = TestExtensions.ServerUuid;
                     options.MAuthServiceUrl = TestExtensions.TestUri;
                     options.PrivateKey = TestExtensions.ServerPrivateKey;
-                    options.MAuthServerHandler = new MAuthServerHandler();
+                    options.MAuthServerHandler = serverHandler;
                     options.HideExceptionsAndReturnUnauthorized = false;
                 });
 
@@ -122,6 +125,7 @@ namespace Medidata.MAuth.Tests
             var testData = await method.FromResourceV2();
             var canSeek = false;
             var body = string.Empty;
+            var serverHandler = await MAuthServerHandler.CreateAsync();
 
             using (var server = WebApp.Start("http://localhost:29999/", app =>
             {
@@ -130,7 +134,7 @@ namespace Medidata.MAuth.Tests
                     options.ApplicationUuid = TestExtensions.ServerUuid;
                     options.MAuthServiceUrl = TestExtensions.TestUri;
                     options.PrivateKey = TestExtensions.ServerPrivateKey;
-                    options.MAuthServerHandler = new MAuthServerHandler();
+                    options.MAuthServerHandler = serverHandler;
                 });
 
                 app.Run(async context =>

--- a/tests/Medidata.MAuth.Tests/MAuthProtocolSuiteTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthProtocolSuiteTests.cs
@@ -1,0 +1,113 @@
+﻿using Medidata.MAuth.Core;
+using Medidata.MAuth.Tests.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Medidata.MAuth.Tests.ProtocolTestSuite
+{
+    public class MAuthProtocolSuiteTests
+    {
+        private readonly ProtocolTestSuiteHelper _protcolTestHelper;
+
+        public MAuthProtocolSuiteTests()
+        {
+            _protcolTestHelper = new ProtocolTestSuiteHelper();
+        }
+
+        [Theory, MemberData(nameof(TestCases))]
+        public async Task MAuth_Execute_ProtocolTestSuite(string caseName)
+        {
+            if (string.IsNullOrEmpty(caseName))
+                return;
+
+            // Arrange
+            var _signConfig = _protcolTestHelper.LoadSigningConfig().Result;
+            var requestData = await _protcolTestHelper.LoadUnsignedRequest(caseName);
+            var authz = await _protcolTestHelper.ReadAuthenticationHeader(caseName);
+
+            var actual = new AssertSigningHandler();
+            var clientOptions = TestExtensions.ProtocolTestClientOptions(
+                    _signConfig.AppUuid, _signConfig.PrivateKey, _signConfig.RequestTime.FromUnixTimeSeconds());
+            clientOptions.DisableV1 = true;
+            var signingHandler = new MAuthSigningHandler(clientOptions, actual);
+            var request = requestData.ToHttpRequestMessage();
+
+            var authInfo = new PrivateKeyAuthenticationInfo()
+            {
+                ApplicationUuid = _signConfig.AppUuid,
+                SignedTime = _signConfig.RequestTime.FromUnixTimeSeconds(),
+                PrivateKey = _signConfig.PrivateKey
+            };
+
+            // Verify Signing and auth headers matches .authz file
+            // Act
+            using (var client = new HttpClient(signingHandler))
+            {
+                await client.SendAsync(request);
+            }
+
+            // Assert
+            Assert.Equal(authz.MccAuthentication, actual.MAuthHeaderV2);
+            Assert.Equal(authz.MccTime, long.Parse(actual.MAuthTimeHeaderV2));
+
+            if (!caseName.StartsWith("authentication-only"))
+            {
+                var sig = await _protcolTestHelper.ReadDigitalSignature(caseName);
+
+                // Verify payload matches digital signature
+                // Act
+                var actualPayload = await new MAuthCoreV2().CalculatePayload(request, authInfo);
+
+                // Assert
+                Assert.Equal(sig, actualPayload);
+
+
+                // Verify string_to_sign is matched
+                // Act 
+                var result = await new MAuthCoreV2().GetSignature(request, authInfo);
+                var sts = await _protcolTestHelper.ReadStringToSign(caseName);
+
+                // Assert
+                Assert.Equal(sts, Encoding.UTF8.GetString(result));
+            }
+            else
+            {
+                var authenticator = new MAuthAuthenticator(
+                    TestExtensions.ServerOptions, NullLogger<MAuthAuthenticator>.Instance);
+
+                var signedRequest = await new MAuthCoreV2()
+                    .AddAuthenticationInfo(request, new PrivateKeyAuthenticationInfo()
+                    {
+                        ApplicationUuid = _signConfig.AppUuid,
+                        PrivateKey = _signConfig.PrivateKey,
+                        SignedTime = _signConfig.RequestTime.FromUnixTimeSeconds()
+                    });
+
+                // Act
+                var isAuthenticated = await authenticator.AuthenticateRequest(signedRequest);
+
+                // Assert
+                Assert.True(isAuthenticated);
+            }
+        }
+
+        public static IEnumerable<object[]> TestCases
+        {
+            get
+            {
+                // Or this could read from a file. :)
+                var cases = new ProtocolTestSuiteHelper().GetTestCases();
+                var data = new List<object[]>();
+                foreach(var item in cases)
+                {
+                    data.Add(new object[] { item });
+                }
+                return data;
+            }
+        }
+    }
+}

--- a/tests/Medidata.MAuth.Tests/MAuthProtocolSuiteTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthProtocolSuiteTests.cs
@@ -25,22 +25,22 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
                 return;
 
             // Arrange
-            var _signConfig = _protcolTestHelper.LoadSigningConfig().Result;
+            var signConfig = await _protcolTestHelper.LoadSigningConfig();
             var requestData = await _protcolTestHelper.LoadUnsignedRequest(caseName);
             var authz = await _protcolTestHelper.ReadAuthenticationHeader(caseName);
 
             var actual = new AssertSigningHandler();
             var clientOptions = TestExtensions.ProtocolTestClientOptions(
-                    _signConfig.AppUuid, _signConfig.PrivateKey, _signConfig.RequestTime.FromUnixTimeSeconds());
+                    signConfig.AppUuid, signConfig.PrivateKey, signConfig.RequestTime.FromUnixTimeSeconds());
             clientOptions.DisableV1 = true;
             var signingHandler = new MAuthSigningHandler(clientOptions, actual);
             var request = requestData.ToHttpRequestMessage();
 
             var authInfo = new PrivateKeyAuthenticationInfo()
             {
-                ApplicationUuid = _signConfig.AppUuid,
-                SignedTime = _signConfig.RequestTime.FromUnixTimeSeconds(),
-                PrivateKey = _signConfig.PrivateKey
+                ApplicationUuid = signConfig.AppUuid,
+                SignedTime = signConfig.RequestTime.FromUnixTimeSeconds(),
+                PrivateKey = signConfig.PrivateKey
             };
 
             // Verify Signing and auth headers matches .authz file
@@ -82,9 +82,9 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
                 var signedRequest = await new MAuthCoreV2()
                     .AddAuthenticationInfo(request, new PrivateKeyAuthenticationInfo()
                     {
-                        ApplicationUuid = _signConfig.AppUuid,
-                        PrivateKey = _signConfig.PrivateKey,
-                        SignedTime = _signConfig.RequestTime.FromUnixTimeSeconds()
+                        ApplicationUuid = signConfig.AppUuid,
+                        PrivateKey = signConfig.PrivateKey,
+                        SignedTime = signConfig.RequestTime.FromUnixTimeSeconds()
                     });
 
                 // Act

--- a/tests/Medidata.MAuth.Tests/MAuthProtocolSuiteTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthProtocolSuiteTests.cs
@@ -37,7 +37,7 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
             var actual = new AssertSigningHandler();
             var clientOptions = ProtocolTestClientOptions(
                     signConfig.AppUuid, signConfig.PrivateKey, signConfig.RequestTime.FromUnixTimeSeconds());
-            clientOptions.SignVersions = MAuthVersion.MWS | MAuthVersion.MWSV2;
+            clientOptions.SignVersions = MAuthVersion.MWSV2;
             var signingHandler = new MAuthSigningHandler(clientOptions, actual);
             var request = ToHttpRequestMessage(requestData);
 
@@ -80,9 +80,7 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
             }
             else
             {
-                var serverOptions = TestExtensions.ServerOptions;
-                serverOptions.MAuthServerHandler = await new MAuthServerHandler().InitializeAsync();
-
+                var serverOptions = TestExtensions.ServerOptions(await MAuthServerHandler.CreateAsync());
                 var authenticator = new MAuthAuthenticator(
                     serverOptions, NullLogger<MAuthAuthenticator>.Instance);
 

--- a/tests/Medidata.MAuth.Tests/MAuthProtocolSuiteTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthProtocolSuiteTests.cs
@@ -1,4 +1,5 @@
 ﻿using Medidata.MAuth.Core;
+using Medidata.MAuth.Core.Models;
 using Medidata.MAuth.Tests.Infrastructure;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Collections.Generic;
@@ -32,7 +33,7 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
             var actual = new AssertSigningHandler();
             var clientOptions = TestExtensions.ProtocolTestClientOptions(
                     signConfig.AppUuid, signConfig.PrivateKey, signConfig.RequestTime.FromUnixTimeSeconds());
-            clientOptions.DisableV1 = true;
+            clientOptions.SignVersions = MAuthVersion.MWS | MAuthVersion.MWSV2;
             var signingHandler = new MAuthSigningHandler(clientOptions, actual);
             var request = requestData.ToHttpRequestMessage();
 

--- a/tests/Medidata.MAuth.Tests/MAuthProtocolSuiteTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthProtocolSuiteTests.cs
@@ -77,8 +77,11 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
             }
             else
             {
+                var serverOptions = TestExtensions.ServerOptions;
+                serverOptions.MAuthServerHandler = await new MAuthServerHandler().InitializeAsync();
+
                 var authenticator = new MAuthAuthenticator(
-                    TestExtensions.ServerOptions, NullLogger<MAuthAuthenticator>.Instance);
+                    serverOptions, NullLogger<MAuthAuthenticator>.Instance);
 
                 var signedRequest = await new MAuthCoreV2()
                     .AddAuthenticationInfo(request, new PrivateKeyAuthenticationInfo()

--- a/tests/Medidata.MAuth.Tests/MAuthProtocolSuiteTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthProtocolSuiteTests.cs
@@ -101,11 +101,16 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
             {
                 // Or this could read from a file. :)
                 var cases = new ProtocolTestSuiteHelper().GetTestCases();
+
+                if (cases is null)
+                    return new List<object[]> { new object[] { string.Empty } };
+
                 var data = new List<object[]>();
-                foreach(var item in cases)
+                foreach (string item in cases)
                 {
                     data.Add(new object[] { item });
                 }
+
                 return data;
             }
         }

--- a/tests/Medidata.MAuth.Tests/MAuthProtocolSuiteTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthProtocolSuiteTests.cs
@@ -24,11 +24,9 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
         }
 
         [Theory, MemberData(nameof(TestCases))]
+        [Trait("Category","ProtocolTestSuite")]
         public async Task MAuth_Execute_ProtocolTestSuite(string caseName)
         {
-            if (string.IsNullOrEmpty(caseName))
-                return;
-
             // Arrange
             var signConfig = await _protcolTestHelper.LoadSigningConfig();
             var requestData = await _protcolTestHelper.LoadUnsignedRequest(caseName);
@@ -100,19 +98,9 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
             }
         }
 
-        public static IEnumerable<object[]> TestCases
-        {
-            get
-            {
-                // Or this could read from a file. :)
-                var cases = new ProtocolTestSuiteHelper().GetTestCases();
-
-                if (cases is null)
-                    return new List<object[]> { new object[] { string.Empty } };
-
-                return cases.Select(tc => new object[] { tc });
-            }
-        }
+        public static IEnumerable<object[]> TestCases =>
+            new ProtocolTestSuiteHelper().GetTestCases()
+            .Select(tc => new object[] { tc });
 
         private static MAuthSigningOptions ProtocolTestClientOptions(Guid clientUuid,
             string clientPrivateKey, DateTimeOffset signedTime) => new MAuthSigningOptions()

--- a/tests/Medidata.MAuth.Tests/MAuthWebApiTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthWebApiTests.cs
@@ -21,13 +21,14 @@ namespace Medidata.MAuth.Tests
             // Arrange
             var testData = await method.FromResource();
             var actual = new AssertSigningHandler();
+            var serverHandler = await MAuthServerHandler.CreateAsync();
 
             var handler = new MAuthAuthenticatingHandler(new MAuthWebApiOptions()
             {
                 ApplicationUuid = TestExtensions.ServerUuid,
                 MAuthServiceUrl = TestExtensions.TestUri,
                 PrivateKey = TestExtensions.ServerPrivateKey,
-                MAuthServerHandler = new MAuthServerHandler()
+                MAuthServerHandler = serverHandler
             }, actual);
 
             using (var server = new HttpClient(handler))
@@ -53,12 +54,14 @@ namespace Medidata.MAuth.Tests
             var testData = await method.FromResourceV2();
             var actual = new AssertSigningHandler();
             var version = MAuthVersion.MWSV2;
+            var serverHandler = await MAuthServerHandler.CreateAsync();
+
             var handler = new MAuthAuthenticatingHandler(new MAuthWebApiOptions()
             {
                 ApplicationUuid = TestExtensions.ServerUuid,
                 MAuthServiceUrl = TestExtensions.TestUri,
                 PrivateKey = TestExtensions.ServerPrivateKey,
-                MAuthServerHandler = new MAuthServerHandler()
+                MAuthServerHandler = serverHandler
             }, actual);
 
             using (var server = new HttpClient(handler))
@@ -82,13 +85,14 @@ namespace Medidata.MAuth.Tests
         {
             // Arrange
             var testData = await method.FromResource();
+            var serverHandler = await MAuthServerHandler.CreateAsync();
 
             var handler = new MAuthAuthenticatingHandler(new MAuthWebApiOptions()
             {
                 ApplicationUuid = TestExtensions.ServerUuid,
                 MAuthServiceUrl = TestExtensions.TestUri,
                 PrivateKey = TestExtensions.ServerPrivateKey,
-                MAuthServerHandler = new MAuthServerHandler()
+                MAuthServerHandler = serverHandler
             });
 
             using (var server = new HttpClient(handler))
@@ -111,13 +115,14 @@ namespace Medidata.MAuth.Tests
         {
             // Arrange
             var testData = await method.FromResource();
+            var serverHandler = await MAuthServerHandler.CreateAsync();
 
             var handler = new MAuthAuthenticatingHandler(new MAuthWebApiOptions()
             {
                 ApplicationUuid = TestExtensions.ServerUuid,
                 MAuthServiceUrl = TestExtensions.TestUri,
                 PrivateKey = TestExtensions.ServerPrivateKey,
-                MAuthServerHandler = new MAuthServerHandler(),
+                MAuthServerHandler = serverHandler,
                 HideExceptionsAndReturnUnauthorized = false
             });
 

--- a/tests/Medidata.MAuth.Tests/ProtocolTestSuite/AuthenticationHeader.cs
+++ b/tests/Medidata.MAuth.Tests/ProtocolTestSuite/AuthenticationHeader.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+
+namespace Medidata.MAuth.Tests.ProtocolTestSuite
+{
+    public class AuthenticationHeader
+    {
+        [JsonProperty(PropertyName = "MCC-Authentication")]
+        public string MccAuthentication { get; set; }
+
+        [JsonProperty(PropertyName = "MCC-Time")]
+        public long MccTime { get; set; }
+
+    }
+}

--- a/tests/Medidata.MAuth.Tests/ProtocolTestSuite/ProtocolTestSuiteHelper.cs
+++ b/tests/Medidata.MAuth.Tests/ProtocolTestSuite/ProtocolTestSuiteHelper.cs
@@ -75,10 +75,9 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
 
         public string[] GetTestCases()
         {
-            var cases = Directory.Exists(_testCasePath)
+            return Directory.Exists(_testCasePath)
                 ? Directory.GetDirectories(_testCasePath).Select(x => Path.GetFileName(x)).ToArray()
-                : new string[1];
-            return cases;
+                : null;
         }
 
         public async Task<string> ReadStringToSign(string testCaseName)

--- a/tests/Medidata.MAuth.Tests/ProtocolTestSuite/ProtocolTestSuiteHelper.cs
+++ b/tests/Medidata.MAuth.Tests/ProtocolTestSuite/ProtocolTestSuiteHelper.cs
@@ -48,6 +48,8 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
         public async Task<string> GetPublicKey()
         {
             var publicKeyFilePath = Path.Combine(_testSuitePath, "signing-params/rsa-key-pub");
+
+            // TODO: remove this try catch when "mauth-protocol-test-suite" is added as submodule
             try
             {
                 return Encoding.UTF8.GetString(await ReadAsBytes(publicKeyFilePath));
@@ -112,6 +114,7 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
 
         private async Task<SigningConfig> ReadSigningConfigParameters(string signingConfigJson)
         {
+            // TODO: remove this try catch when "mauth-protocol-test-suite" is added as submodule
             try
             {
                 var signingConfigBytes = await ReadAsBytes(signingConfigJson);

--- a/tests/Medidata.MAuth.Tests/ProtocolTestSuite/ProtocolTestSuiteHelper.cs
+++ b/tests/Medidata.MAuth.Tests/ProtocolTestSuite/ProtocolTestSuiteHelper.cs
@@ -17,13 +17,13 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
             var currentDirectory = Environment.CurrentDirectory;
             _testSuitePath = Environment.GetEnvironmentVariable("TEST_SUITE_PATH") != null
                 ? Environment.GetEnvironmentVariable("TEST_SUITE_PATH")
-                : Path.GetFullPath(Path.Combine(currentDirectory, @"..\..\..\..\..\..\mauth-protocol-test-suite"));
-            _testCasePath = $"{_testSuitePath}/protocols/MWSV2";
+                : Path.GetFullPath(Path.Combine(currentDirectory, "../../../../../../mauth-protocol-test-suite"));
+            _testCasePath = Path.Combine(_testSuitePath, "protocols/MWSV2");
         }
 
         public async Task<SigningConfig> LoadSigningConfig()
         {
-            var configFile = $"{_testSuitePath}/signing-config.json";
+            var configFile = Path.Combine(_testSuitePath, "signing-config.json");
 
             var signingConfig = await ReadSigningConfigParameters(configFile);
             if (signingConfig is null )return null;
@@ -40,19 +40,19 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
 
         public async Task<string> GetPrivateKey()
         {
-            var filePath = $"{_testSuitePath}/signing-params/rsa-key";
+            var filePath = Path.Combine(_testSuitePath, "signing-params/rsa-key");
             return await ReadValueFromPath(filePath);
         }
 
         public async Task<string> GetPublicKey()
         {
-            var publicKeyFilePath = $"{_testSuitePath}/signing-params/rsa-key-pub";
+            var publicKeyFilePath = Path.Combine(_testSuitePath, "signing-params/rsa-key-pub");
             return await ReadValueFromPath(publicKeyFilePath);
         }
 
         public async Task<UnSignedRequest> LoadUnsignedRequest(string testCaseName)
         {
-            var reqFilePath = $"{_testCasePath}/{testCaseName}/{testCaseName}.req";
+            var reqFilePath = Path.Combine(_testCasePath, testCaseName, $"{testCaseName}.req");
             var unsignedRequest = await ReadRequestParameters(reqFilePath);
             unsignedRequest.Body = !string.IsNullOrEmpty(unsignedRequest.Body) 
                 ? Convert.ToBase64String(unsignedRequest.Body.ToBytes()) : unsignedRequest.Body;
@@ -68,7 +68,7 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
         {
             if (string.IsNullOrEmpty(bodyFilepath))
                 return null;
-            var completebodyFilePath = $"{_testCasePath}/{caseName}/{bodyFilepath}";
+            var completebodyFilePath = Path.Combine(_testCasePath, caseName, bodyFilepath);
             var bytes = File.ReadAllBytes(completebodyFilePath);
             return Convert.ToBase64String(bytes);
         }
@@ -82,20 +82,20 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
 
         public async Task<string> ReadStringToSign(string testCaseName)
         {
-            var stsFilePath = $"{_testCasePath}/{testCaseName}/{testCaseName}.sts";
+            var stsFilePath = Path.Combine(_testCasePath, testCaseName, $"{testCaseName}.sts");
             var sts = await ReadValueFromPath(stsFilePath);
             return sts.Replace("\r", "");
         }
 
         public async Task<string> ReadDigitalSignature(string testCaseName)
         {
-            var sigFilePath = $"{_testCasePath}/{testCaseName}/{testCaseName}.sig";
+            var sigFilePath = Path.Combine(_testCasePath, testCaseName, $"{testCaseName}.sig");
             return await ReadValueFromPath(sigFilePath);
         }
 
         public async Task<AuthenticationHeader> ReadAuthenticationHeader(string testCaseName)
         {
-            var authzFilePath = $"{_testCasePath}/{testCaseName}/{testCaseName}.authz";
+            var authzFilePath = Path.Combine(_testCasePath, testCaseName, $"{testCaseName}.authz");
             return JsonConvert.DeserializeObject<AuthenticationHeader>(
                 await ReadValueFromPath(authzFilePath));
         }
@@ -109,7 +109,6 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
             var signingConfig = await ReadValueFromPath(signingConfigJson);
             return signingConfig != null ? JsonConvert.DeserializeObject<SigningConfig>(signingConfig) : null;
         }
-           
 
         private async Task<string> ReadValueFromPath(string filePath)
         {

--- a/tests/Medidata.MAuth.Tests/ProtocolTestSuite/ProtocolTestSuiteHelper.cs
+++ b/tests/Medidata.MAuth.Tests/ProtocolTestSuite/ProtocolTestSuiteHelper.cs
@@ -53,23 +53,23 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
         public async Task<UnSignedRequest> LoadUnsignedRequest(string testCaseName)
         {
             var reqFilePath = Path.Combine(_testCasePath, testCaseName, $"{testCaseName}.req");
-            var unsignedRequest = await ReadRequestParameters(reqFilePath);
+            var unsignedRequest = await ReadUnsignedRequest(reqFilePath);
             unsignedRequest.Body = !string.IsNullOrEmpty(unsignedRequest.Body) 
                 ? Convert.ToBase64String(unsignedRequest.Body.ToBytes()) : unsignedRequest.Body;
 
             if (!string.IsNullOrEmpty(unsignedRequest.BodyFilePath))
             {
-                unsignedRequest.Body = GetTestRequestBody(testCaseName, unsignedRequest.BodyFilePath);
+                unsignedRequest.Body = await GetTestRequestBody(testCaseName, unsignedRequest.BodyFilePath);
             }
             return unsignedRequest;
         }
 
-        public string GetTestRequestBody(string caseName, string bodyFilepath)
+        public async Task<string> GetTestRequestBody(string caseName, string bodyFilepath)
         {
             if (string.IsNullOrEmpty(bodyFilepath))
                 return null;
             var completebodyFilePath = Path.Combine(_testCasePath, caseName, bodyFilepath);
-            var bytes = File.ReadAllBytes(completebodyFilePath);
+            var bytes = await ReadBytes(completebodyFilePath);
             return Convert.ToBase64String(bytes);
         }
 
@@ -100,7 +100,7 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
                 await ReadValueFromPath(authzFilePath));
         }
 
-        private async Task<UnSignedRequest> ReadRequestParameters(string requestPath) =>
+        private async Task<UnSignedRequest> ReadUnsignedRequest(string requestPath) =>
             JsonConvert.DeserializeObject<UnSignedRequest>(
                 await ReadValueFromPath(requestPath));
 
@@ -122,6 +122,16 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
             catch (Exception ex)
             {
                 return null;
+            }
+        }
+
+        private async Task<byte[]> ReadBytes(string filePath)
+        {
+            using (FileStream stream = File.OpenRead(filePath))
+            {
+                byte[] result = new byte[stream.Length];
+                await stream.ReadAsync(result, 0, (int)stream.Length);
+                return result;
             }
         }
     }

--- a/tests/Medidata.MAuth.Tests/ProtocolTestSuite/ProtocolTestSuiteHelper.cs
+++ b/tests/Medidata.MAuth.Tests/ProtocolTestSuite/ProtocolTestSuiteHelper.cs
@@ -1,0 +1,131 @@
+﻿using Medidata.MAuth.Core;
+using Newtonsoft.Json;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Medidata.MAuth.Tests.ProtocolTestSuite
+{
+    public class ProtocolTestSuiteHelper
+    {
+        private string _testSuitePath;
+        private string _testCasePath;
+
+        public ProtocolTestSuiteHelper()
+        {
+            var currentDirectory = Environment.CurrentDirectory;
+            _testSuitePath = Environment.GetEnvironmentVariable("TEST_SUITE_PATH") != null
+                ? Environment.GetEnvironmentVariable("TEST_SUITE_PATH")
+                : Path.GetFullPath(Path.Combine(currentDirectory, @"..\..\..\..\..\..\mauth-protocol-test-suite"));
+            _testCasePath = $"{_testSuitePath}/protocols/MWSV2";
+        }
+
+        public async Task<SigningConfig> LoadSigningConfig()
+        {
+            var configFile = $"{_testSuitePath}/signing-config.json";
+
+            var signingConfig = await ReadSigningConfigParameters(configFile);
+            if (signingConfig is null )return null;
+
+            signingConfig.PrivateKey = await GetPrivateKey();
+            return signingConfig;
+        }
+
+        public async Task<Guid> ReadSignInAppUuid()
+        {
+            var signConfig = await LoadSigningConfig();
+            return signConfig != null ? signConfig.AppUuid : default;
+        }
+
+        public async Task<string> GetPrivateKey()
+        {
+            var filePath = $"{_testSuitePath}/signing-params/rsa-key";
+            return await ReadValueFromPath(filePath);
+        }
+
+        public async Task<string> GetPublicKey()
+        {
+            var publicKeyFilePath = $"{_testSuitePath}/signing-params/rsa-key-pub";
+            return await ReadValueFromPath(publicKeyFilePath);
+        }
+
+        public async Task<UnSignedRequest> LoadUnsignedRequest(string testCaseName)
+        {
+            var reqFilePath = $"{_testCasePath}/{testCaseName}/{testCaseName}.req";
+            var unsignedRequest = await ReadRequestParameters(reqFilePath);
+            unsignedRequest.Body = !string.IsNullOrEmpty(unsignedRequest.Body) 
+                ? Convert.ToBase64String(unsignedRequest.Body.ToBytes()) : unsignedRequest.Body;
+
+            if (!string.IsNullOrEmpty(unsignedRequest.BodyFilePath))
+            {
+                unsignedRequest.Body = GetTestRequestBody(testCaseName, unsignedRequest.BodyFilePath);
+            }
+            return unsignedRequest;
+        }
+
+        public string GetTestRequestBody(string caseName, string bodyFilepath)
+        {
+            if (string.IsNullOrEmpty(bodyFilepath))
+                return null;
+            var completebodyFilePath = $"{_testCasePath}/{caseName}/{bodyFilepath}";
+            var bytes = File.ReadAllBytes(completebodyFilePath);
+            return Convert.ToBase64String(bytes);
+        }
+
+        public string[] GetTestCases()
+        {
+            var cases = Directory.Exists(_testCasePath)
+                ? Directory.GetDirectories(_testCasePath).Select(x => Path.GetFileName(x)).ToArray()
+                : new string[1];
+            return cases;
+        }
+
+        public async Task<string> ReadStringToSign(string testCaseName)
+        {
+            var stsFilePath = $"{_testCasePath}/{testCaseName}/{testCaseName}.sts";
+            var sts = await ReadValueFromPath(stsFilePath);
+            return sts.Replace("\r", "");
+        }
+
+        public async Task<string> ReadDigitalSignature(string testCaseName)
+        {
+            var sigFilePath = $"{_testCasePath}/{testCaseName}/{testCaseName}.sig";
+            return await ReadValueFromPath(sigFilePath);
+        }
+
+        public async Task<AuthenticationHeader> ReadAuthenticationHeader(string testCaseName)
+        {
+            var authzFilePath = $"{_testCasePath}/{testCaseName}/{testCaseName}.authz";
+            return JsonConvert.DeserializeObject<AuthenticationHeader>(
+                await ReadValueFromPath(authzFilePath));
+        }
+
+        private async Task<UnSignedRequest> ReadRequestParameters(string requestPath) =>
+            JsonConvert.DeserializeObject<UnSignedRequest>(
+                await ReadValueFromPath(requestPath));
+
+        private async Task<SigningConfig> ReadSigningConfigParameters(string signingConfigJson)
+        {
+            var signingConfig = await ReadValueFromPath(signingConfigJson);
+            return signingConfig != null ? JsonConvert.DeserializeObject<SigningConfig>(signingConfig) : null;
+        }
+           
+
+        private async Task<string> ReadValueFromPath(string filePath)
+        {
+            try
+            {
+                using (StreamReader sr = File.OpenText(filePath))
+                {
+                    return await sr.ReadToEndAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                return null;
+            }
+        }
+    }
+
+}

--- a/tests/Medidata.MAuth.Tests/ProtocolTestSuite/SigningConfig.cs
+++ b/tests/Medidata.MAuth.Tests/ProtocolTestSuite/SigningConfig.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace Medidata.MAuth.Tests.ProtocolTestSuite
+{
+    public class SigningConfig
+    {
+        [JsonProperty(PropertyName ="app_uuid")]
+        public Guid AppUuid { get; set; }
+
+        [JsonProperty(PropertyName = "request_time")]
+        public long RequestTime { get; set; }
+
+        [JsonProperty(PropertyName = "private_key_file")]
+        public string PrivateKeyFile { get; set; }
+
+        public string PrivateKey { get; set; }
+    }
+}

--- a/tests/Medidata.MAuth.Tests/ProtocolTestSuite/UnSignedRequest.cs
+++ b/tests/Medidata.MAuth.Tests/ProtocolTestSuite/UnSignedRequest.cs
@@ -15,9 +15,5 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
 
         [JsonProperty(PropertyName = "body_filepath")]
         public string BodyFilePath { get; set; }
-
-        public string BodyResourcePath { get; }
-
-        public string QueryString { get; }
     }
 }

--- a/tests/Medidata.MAuth.Tests/ProtocolTestSuite/UnSignedRequest.cs
+++ b/tests/Medidata.MAuth.Tests/ProtocolTestSuite/UnSignedRequest.cs
@@ -1,0 +1,23 @@
+﻿using Newtonsoft.Json;
+
+namespace Medidata.MAuth.Tests.ProtocolTestSuite
+{
+    public class UnSignedRequest
+    {
+        [JsonProperty(PropertyName = "verb")]
+        public string Verb { get; set; }
+
+        [JsonProperty(PropertyName = "url")]
+        public string Url { get; set; }
+
+        [JsonProperty(PropertyName = "body")]
+        public string Body { get; set; }
+
+        [JsonProperty(PropertyName = "body_filepath")]
+        public string BodyFilePath { get; set; }
+
+        public string BodyResourcePath { get; }
+
+        public string QueryString { get; }
+    }
+}

--- a/tests/Medidata.MAuth.Tests/UtilityExtensionsTest.cs
+++ b/tests/Medidata.MAuth.Tests/UtilityExtensionsTest.cs
@@ -68,7 +68,8 @@ namespace Medidata.MAuth.Tests
                 });
 
             // Act
-            var isAuthenticated = await signedRequest.Authenticate(TestExtensions.ServerOptions, NullLogger.Instance);
+            var isAuthenticated = await signedRequest.Authenticate(
+                TestExtensions.ServerOptions(await MAuthServerHandler.CreateAsync()), NullLogger.Instance);
 
             // Assert
             Assert.True(isAuthenticated);

--- a/tests/Medidata.MAuth.Tests/xunit.runner.json
+++ b/tests/Medidata.MAuth.Tests/xunit.runner.json
@@ -1,3 +1,5 @@
 ﻿{
-  "methodDisplay": "method"
+  "methodDisplay": "method",
+  "parallelizeTestCollections": false,
+  "maxParallelThreads": 1
 }

--- a/tests/Medidata.MAuth.Tests/xunit.runner.json
+++ b/tests/Medidata.MAuth.Tests/xunit.runner.json
@@ -1,5 +1,3 @@
 ﻿{
-  "methodDisplay": "method",
-  "parallelizeTestCollections": false,
-  "maxParallelThreads": 1
+  "methodDisplay": "method"
 }


### PR DESCRIPTION
Following the changes made in https://github.com/mdsol/mauth-client-python/pull/15
and https://github.com/mdsol/mauth-client-ruby/pull/39

Updates includes

- Add [mauth-protocol-test-suite](https://github.com/mdsol/mauth-protocol-test-suite)
- Updated Sorting part in `BuildEncodedQueryParams` 

Please review 
@mdsol/architecture-enablement 
@mdsol/libraries_dotnet 
@mdsol/team-51 
