### PR TITLE
[Housekeeping] Prefix private variable with underscore 

### DIFF
--- a/src/Medidata.MAuth.AspNetCore/MAuthMiddleware.cs
+++ b/src/Medidata.MAuth.AspNetCore/MAuthMiddleware.cs
@@ -12,9 +12,9 @@ namespace Medidata.MAuth.AspNetCore
     /// </summary>
     internal class MAuthMiddleware
     {
-        private readonly MAuthMiddlewareOptions options;
-        private readonly MAuthAuthenticator authenticator;
-        private readonly RequestDelegate next;
+        private readonly MAuthMiddlewareOptions _options;
+        private readonly MAuthAuthenticator _authenticator;
+        private readonly RequestDelegate _next;
 
         /// <summary>
         /// Creates a new <see cref="MAuthMiddleware"/>
@@ -24,11 +24,11 @@ namespace Medidata.MAuth.AspNetCore
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> representing the factory that used to create logger instances.</param>
         public MAuthMiddleware(RequestDelegate next, MAuthMiddlewareOptions options, ILoggerFactory loggerFactory)
         {
-            this.next = next;
-            this.options = options;
+            _next = next;
+            _options = options;
             loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
             ILogger logger = loggerFactory.CreateLogger<MAuthMiddleware>();
-            this.authenticator = new MAuthAuthenticator(options, logger); 
+            _authenticator = new MAuthAuthenticator(options, logger); 
         }
 
         /// <summary>
@@ -40,8 +40,8 @@ namespace Medidata.MAuth.AspNetCore
         {
             context.Request.EnableBuffering();
 
-            if (!options.Bypass(context.Request) &&
-                !await context.TryAuthenticate(authenticator, options.HideExceptionsAndReturnUnauthorized).ConfigureAwait(false))
+            if (!_options.Bypass(context.Request) &&
+                !await context.TryAuthenticate(_authenticator, _options.HideExceptionsAndReturnUnauthorized).ConfigureAwait(false))
             {
                 context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
                 return;
@@ -49,7 +49,7 @@ namespace Medidata.MAuth.AspNetCore
 
             context.Request.Body.Rewind();
 
-            await next.Invoke(context).ConfigureAwait(false);
+            await _next.Invoke(context).ConfigureAwait(false);
         }
     }
 }

--- a/src/Medidata.MAuth.Owin/MAuthMiddleware.cs
+++ b/src/Medidata.MAuth.Owin/MAuthMiddleware.cs
@@ -8,21 +8,22 @@ namespace Medidata.MAuth.Owin
 {
     internal class MAuthMiddleware: OwinMiddleware
     {
-        private readonly MAuthMiddlewareOptions options;
-        private readonly MAuthAuthenticator authenticator;
+        private readonly MAuthMiddlewareOptions _options;
+        private readonly MAuthAuthenticator _authenticator;
 
         public MAuthMiddleware(OwinMiddleware next, MAuthMiddlewareOptions options, ILogger owinLogger) : base(next)
         {
-            this.options = options;
+            _options = options;
             Microsoft.Extensions.Logging.ILogger logger = new OwinLoggerWrapper(owinLogger); 
-            authenticator = new MAuthAuthenticator(options, logger);
+            _authenticator = new MAuthAuthenticator(options, logger);
         }
 
         public override async Task Invoke(IOwinContext context)
         {
             await context.EnsureRequestBodyStreamSeekable().ConfigureAwait(false);
-            if (!options.Bypass(context.Request) &&
-                !await context.TryAuthenticate(authenticator, options.HideExceptionsAndReturnUnauthorized).ConfigureAwait(false))
+            if (!_options.Bypass(context.Request) &&
+                !await context.TryAuthenticate(_authenticator, _options.HideExceptionsAndReturnUnauthorized)
+                .ConfigureAwait(false))
             {
                 context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
                 return;

--- a/src/Medidata.MAuth.WebApi/MAuthAuthenticatingHandler.cs
+++ b/src/Medidata.MAuth.WebApi/MAuthAuthenticatingHandler.cs
@@ -15,11 +15,11 @@ namespace Medidata.MAuth.WebApi
     /// </summary>
     public class MAuthAuthenticatingHandler : DelegatingHandler
     {
-        private readonly MAuthWebApiOptions options;
-        private readonly MAuthAuthenticator authenticator;
+        private readonly MAuthWebApiOptions _options;
+        private readonly MAuthAuthenticator _authenticator;
 
         /// <summary>Gets the Uuid of the client application.</summary>
-        public Guid ClientAppUuid => authenticator.ApplicationUuid;
+        public Guid ClientAppUuid => _authenticator.ApplicationUuid;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MAuthAuthenticatingHandler"/> class with the provided
@@ -28,8 +28,8 @@ namespace Medidata.MAuth.WebApi
         /// <param name="options">The options for this message handler.</param>
         public MAuthAuthenticatingHandler(MAuthWebApiOptions options)
         {
-            this.options = options;
-            this.authenticator = this.SetupMAuthAuthenticator(options);
+            _options = options;
+            _authenticator = SetupMAuthAuthenticator(options);
         }
 
         /// <summary>
@@ -42,8 +42,8 @@ namespace Medidata.MAuth.WebApi
         /// </param>
         public MAuthAuthenticatingHandler(MAuthWebApiOptions options, HttpMessageHandler innerHandler) : base(innerHandler)
         {
-            this.options = options;
-            this.authenticator = this.SetupMAuthAuthenticator(options);
+            _options = options;
+            _authenticator = SetupMAuthAuthenticator(options);
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace Medidata.MAuth.WebApi
             if (InnerHandler == null)
                 InnerHandler = new HttpClientHandler();
 
-            if (!await request.TryAuthenticate(authenticator, options.HideExceptionsAndReturnUnauthorized).ConfigureAwait(false))
+            if (!await request.TryAuthenticate(_authenticator, _options.HideExceptionsAndReturnUnauthorized).ConfigureAwait(false))
                 return new HttpResponseMessage(HttpStatusCode.Unauthorized) { RequestMessage = request };
 
             return await base
@@ -70,9 +70,9 @@ namespace Medidata.MAuth.WebApi
 
         private MAuthAuthenticator SetupMAuthAuthenticator(MAuthWebApiOptions opt)
         {
-            var loggerFactory = options.LoggerFactory ?? NullLoggerFactory.Instance;
+            var loggerFactory = _options.LoggerFactory ?? NullLoggerFactory.Instance;
             var logger = loggerFactory.CreateLogger(typeof(MAuthAuthenticatingHandler));
-            return new MAuthAuthenticator(options, logger);
+            return new MAuthAuthenticator(_options, logger);
         }
     }
 }

--- a/tests/Medidata.MAuth.Tests/Infrastructure/NonSeekableStream.cs
+++ b/tests/Medidata.MAuth.Tests/Infrastructure/NonSeekableStream.cs
@@ -5,16 +5,16 @@ namespace Medidata.MAuth.Tests.Infrastructure
 {
     internal class NonSeekableStream: Stream
     {
-        private readonly Stream baseStream;
+        private readonly Stream _baseStream;
 
 
         public override bool CanSeek => false;
 
-        public override bool CanRead => baseStream.CanRead;
+        public override bool CanRead => _baseStream.CanRead;
 
-        public override bool CanWrite => baseStream.CanWrite;
+        public override bool CanWrite => _baseStream.CanWrite;
 
-        public override long Length => baseStream.Length;
+        public override long Length => _baseStream.Length;
 
         public override long Position
         {
@@ -22,16 +22,16 @@ namespace Medidata.MAuth.Tests.Infrastructure
             set => throw new NotSupportedException();
         }
 
-        public NonSeekableStream(Stream baseStream) => this.baseStream = baseStream;
+        public NonSeekableStream(Stream baseStream) => _baseStream = baseStream;
 
         public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
 
-        public override void Flush() => baseStream.Flush();
+        public override void Flush() => _baseStream.Flush();
 
         public override void SetLength(long value) => throw new NotSupportedException();
 
-        public override int Read(byte[] buffer, int offset, int count) => baseStream.Read(buffer, offset, count);
+        public override int Read(byte[] buffer, int offset, int count) => _baseStream.Read(buffer, offset, count);
 
-        public override void Write(byte[] buffer, int offset, int count) => baseStream.Write(buffer, offset, count);
+        public override void Write(byte[] buffer, int offset, int count) => _baseStream.Write(buffer, offset, count);
     }
 }

--- a/tests/Medidata.MAuth.Tests/Infrastructure/RequestBodyAsNonSeekableMiddleware.cs
+++ b/tests/Medidata.MAuth.Tests/Infrastructure/RequestBodyAsNonSeekableMiddleware.cs
@@ -6,9 +6,9 @@ namespace Medidata.MAuth.Tests.Infrastructure
 {
     internal class RequestBodyAsNonSeekableMiddleware
     {
-        private readonly RequestDelegate next;
+        private readonly RequestDelegate _next;
 
-        public RequestBodyAsNonSeekableMiddleware(RequestDelegate next) => this.next = next;
+        public RequestBodyAsNonSeekableMiddleware(RequestDelegate next) => _next = next;
 
         public async Task Invoke(HttpContext context)
         {
@@ -18,7 +18,7 @@ namespace Medidata.MAuth.Tests.Infrastructure
                 context.Request.Body = body;
             }
 
-            await next.Invoke(context);
+            await _next.Invoke(context);
         }
     }
 }


### PR DESCRIPTION
As stated in the title.
This PR is for:

- Updating private variable prefixed with `_`
- Remove `this` keyword when referring to private variable.

Please review:
@mdsol/team-51 
@mdsol/libraries_dotnet 
@hkurniawan-mdsol 
@mdsol/architecture-enablement 
