### PR TITLE
[MCC-655130] Inflate private key upon set in options classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes in Medidata.MAuth
 
+## v5.0.1
+- **[Core]** Inflate private key upon set in options classes.
+
 ## v5.0.0
  - **[Core]** Added normalization of Uri AbsolutePath.
  - **[Core]** Added unescape step in query_string encoding to remove `double encoding`.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ public async Task<HttpResponseMessage> SignAndSendRequest(HttpRequestMessage req
         ApplicationUuid = new Guid("7c872d75-986b-4c61-bb17-f2569d42bfb0"),
 
         // The following can be either a path to the key file or the contents of the file itself
-        // NOTE: if given a path, the file is read every time, no caching of the contents takes place
         PrivateKey = "ClientPrivateKey.pem",
 
         // Enumerations of signing protocols, if not provided defaults to `MAuthVersion.MWS`for sign-in.
@@ -168,7 +167,6 @@ public class Startup
             options.AuthenticateRequestTimeoutSeconds = 3;
             options.MAuthServiceRetryPolicy = MAuthServiceRetryPolicy.RetryOnce;
             options.HideExceptionsAndReturnUnauthorized = true;
-            // NOTE: if given a path, the file is read every time, no caching of the contents takes place
             options.PrivateKey = "ServerPrivateKey.pem";
             options.Bypass = (request) => request.Uri.AbsolutePath.StartsWith("/allowed");
 
@@ -205,7 +203,6 @@ public class Startup
             options.AuthenticateRequestTimeoutSeconds = 3;
             options.MAuthServiceRetryPolicy = MAuthServiceRetryPolicy.RetryOnce;
             options.HideExceptionsAndReturnUnauthorized = true;
-            // NOTE: if given a path, the file is read every time, no caching of the contents takes place
             options.PrivateKey = "ServerPrivateKey.pem";
             options.Bypass = (request) => request.Uri.AbsolutePath.StartsWith("/allowed");
 
@@ -269,7 +266,6 @@ public static class WebApiConfig
             AuthenticateRequestTimeoutSeconds = 3,
             MAuthServiceRetryPolicy = MAuthServiceRetryPolicy.RetryOnce,
             HideExceptionsAndReturnUnauthorized = true,
-            // NOTE: if given a path, the file is read every time, no caching of the contents takes place
             PrivateKey = "ServerPrivateKey.pem",
 
             // when ready to disable authentication of V1 protococl

--- a/src/Medidata.MAuth.Core/MAuthCore.cs
+++ b/src/Medidata.MAuth.Core/MAuthCore.cs
@@ -25,7 +25,7 @@ namespace Medidata.MAuth.Core
             {
                 ApplicationUuid = options.ApplicationUuid,
                 SignedTime = options.SignedTime ?? DateTimeOffset.UtcNow,
-                PrivateKey = options.PrivateKey.Dereference().NormalizeLines()
+                PrivateKey = options.PrivateKey
             });
         }
 

--- a/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
+++ b/src/Medidata.MAuth.Core/MAuthCoreExtensions.cs
@@ -144,10 +144,13 @@ namespace Medidata.MAuth.Core
             return stream;
         }
 
-        public static string Dereference(this string keyPathOrKey) =>
+        public static string Inflate(this string keyPathOrKey) =>
+            keyPathOrKey?.Dereference().NormalizeLines();
+
+        private static string Dereference(this string keyPathOrKey) =>
             keyPathOrKey.IsValidPath() ? File.ReadAllText(keyPathOrKey) : keyPathOrKey;
 
-        public static string NormalizeLines(this string key) =>
+        private static string NormalizeLines(this string key) =>
             key.RemoveLineBreaks().InsertLineBreakAfterBegin().InsertLineBreakBeforeEnd();
 
         private static bool IsValidPath(this string value) =>

--- a/src/Medidata.MAuth.Core/MAuthCoreV2.cs
+++ b/src/Medidata.MAuth.Core/MAuthCoreV2.cs
@@ -23,7 +23,7 @@ namespace Medidata.MAuth.Core
             {
                 ApplicationUuid = options.ApplicationUuid,
                 SignedTime = options.SignedTime ?? DateTimeOffset.UtcNow,
-                PrivateKey = options.PrivateKey.Dereference().NormalizeLines()
+                PrivateKey = options.PrivateKey
             });
         }
 

--- a/src/Medidata.MAuth.Core/Options/MAuthOptionsBase.cs
+++ b/src/Medidata.MAuth.Core/Options/MAuthOptionsBase.cs
@@ -8,11 +8,18 @@ namespace Medidata.MAuth.Core
     /// </summary>
     public abstract class MAuthOptionsBase
     {
+        private string _privateKey;
+
         /// <summary>
         /// Determines the RSA private key for the authentication requests. The value of this property can be set as a
-        /// valid path to a readable key file as well.
+        /// valid path to a readable key file as well. After set, this property will either contain an inflated
+        /// private key or `null`.
         /// </summary>
-        public string PrivateKey { get; set; }
+        public string PrivateKey
+        {
+            get => _privateKey;
+            set => _privateKey = value.Inflate();
+        }
 
         /// <summary>Determines the endpoint of the MAuth authentication service.</summary>
         public Uri MAuthServiceUrl { get; set; }

--- a/src/Medidata.MAuth.Core/Options/MAuthSigningOptions.cs
+++ b/src/Medidata.MAuth.Core/Options/MAuthSigningOptions.cs
@@ -9,10 +9,17 @@ namespace Medidata.MAuth.Core
     /// </summary>
     public class MAuthSigningOptions
     {
+        private string _privateKey;
+
         /// <summary>
         /// Determines the RSA private key for the authentication requests. The value of this property can be set as a
-        /// valid path to a readable key file as well.</summary>
-        public string PrivateKey { get; set; }
+        /// valid path to a readable key file as well.After set, this property will either contain an inflated
+        /// private key or `null`.
+        /// </summary>
+        public string PrivateKey {
+            get => _privateKey;
+            set => _privateKey = value.Inflate();
+        }
 
         /// <summary>Determines the unique identifier used for the MAuth service authentication requests.</summary>
         public Guid ApplicationUuid { get; set; }

--- a/tests/Medidata.MAuth.Tests/MAuthCoreTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthCoreTests.cs
@@ -149,10 +149,26 @@ namespace Medidata.MAuth.Tests
             var keyPath = $"Mocks\\Keys\\{keyFilename}";
 
             // Act
-            var exception = Record.Exception(() => keyPath.Dereference().NormalizeLines().AsCipherParameters());
+            var exception = Record.Exception(() => keyPath.Inflate().AsCipherParameters());
 
             // Assert
             Assert.Null(exception);
+        }
+
+        [Theory]
+        [InlineData("LinuxLineEnding.pem")]
+        [InlineData("WindowsLineEnding.pem")]
+        [InlineData("NoLineEnding.pem")]
+        public static void MAuthSigningOptions_InflatesPrivateKey_OnSet(string keyFilename)
+        {
+            // Arrange
+            var expectedPrivateKeyContents = keyFilename.Inflate();
+
+            // Act
+            var signingOptions = new MAuthSigningOptions { PrivateKey = keyFilename };
+
+            // Assert
+            Assert.Equal(expectedPrivateKeyContents, signingOptions.PrivateKey);
         }
     }
 }

--- a/tests/Medidata.MAuth.Tests/MAuthOwinTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthOwinTests.cs
@@ -15,6 +15,22 @@ namespace Medidata.MAuth.Tests
     public static class MAuthOwinTests
     {
         [Theory]
+        [InlineData("LinuxLineEnding.pem")]
+        [InlineData("WindowsLineEnding.pem")]
+        [InlineData("NoLineEnding.pem")]
+        public static void MAuthMiddlewareOptions_InflatesPrivateKey_OnSet(string keyFilename)
+        {
+            // Arrange
+            var expectedPrivateKeyContents = keyFilename.Inflate();
+
+            // Act
+            var signingOptions = new MAuthMiddlewareOptions { PrivateKey = keyFilename };
+
+            // Assert
+            Assert.Equal(expectedPrivateKeyContents, signingOptions.PrivateKey);
+        }
+
+        [Theory]
         [InlineData("GET")]
         [InlineData("DELETE")]
         [InlineData("POST")]

--- a/tests/Medidata.MAuth.Tests/MAuthWebApiTests.cs
+++ b/tests/Medidata.MAuth.Tests/MAuthWebApiTests.cs
@@ -12,6 +12,22 @@ namespace Medidata.MAuth.Tests
     public static class MAuthWebApiTests
     {
         [Theory]
+        [InlineData("LinuxLineEnding.pem")]
+        [InlineData("WindowsLineEnding.pem")]
+        [InlineData("NoLineEnding.pem")]
+        public static void MAuthWebApiOptions_InflatesPrivateKey_OnSet(string keyFilename)
+        {
+            // Arrange
+            var expectedPrivateKeyContents = keyFilename.Inflate();
+
+            // Act
+            var signingOptions = new MAuthWebApiOptions { PrivateKey = keyFilename };
+
+            // Assert
+            Assert.Equal(expectedPrivateKeyContents, signingOptions.PrivateKey);
+        }
+
+        [Theory]
         [InlineData("GET")]
         [InlineData("DELETE")]
         [InlineData("POST")]

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>5.0.0</Version>
+    <Version>5.0.1</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Follow-up on #67.

Related to https://jira.mdsol.com/browse/MCC-655130.

Inflate private key upon set in the `_Options` classes in order to avoid reading it from disk every time a request is signed.