### PR TITLE
[MCC-721105] Avoid Multiple Outbound Requests for Application Info When Not Already Cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## v5.1.0
 - **[Core]** Added multi-target for .NET 5 to support synchronus HttpClient requests.  
 - **[Core]** Updated MAuthSigningHandler to sign synchronus requests.  
+- **[Core]** Updated MAuthAuthenticator to create and reuse a single HttpClient instead of creating a new one for each MAuthRequestRetrier.
+- **[Core]** Updated MAuthAuthenticator to limit the calls to the cache item factory method to a single thread per key not already in the cache.
 
 ## v5.0.1
 - **[Core]** Inflate private key upon set in options classes.

--- a/src/Medidata.MAuth.Core/AsyncLazy.cs
+++ b/src/Medidata.MAuth.Core/AsyncLazy.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Medidata.MAuth.Core
+{
+    public class AsyncLazy<T> : Lazy<Task<T>>
+    {
+        public AsyncLazy(Func<T> valueFactory)
+            : base(() => Task.Factory.StartNew(valueFactory))
+        {
+        }
+
+        public AsyncLazy(Func<Task<T>> taskFactory)
+            : base(() => Task.Factory.StartNew(() => taskFactory()).Unwrap())
+        {
+        }
+
+        public TaskAwaiter<T> GetAwaiter() => Value.GetAwaiter();
+
+        public ConfiguredTaskAwaitable<T> ConfigureAwait(bool continueOnCapturedContext) 
+            => Value.ConfigureAwait(continueOnCapturedContext);
+    }
+}

--- a/src/Medidata.MAuth.Core/CacheExtensions.cs
+++ b/src/Medidata.MAuth.Core/CacheExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Medidata.MAuth.Core
+{
+    /// <summary>
+    /// Caching-related extension methods.
+    /// </summary>
+    public static class CacheExtensions
+    {
+        /// <summary>
+        /// Get or create an item in the cache.  If the specified key does not exist, the factory method will be executed to
+        /// create a new item, and that item will be inserted into the cache with that key.  Locking is based on the cache
+        /// key, to prevent multiple concurrent factory methods from executing for a single key, but allow multiple concurrent
+        /// factory methods to execute for different keys.
+        /// </summary>
+        /// <param name="cache">The memory cache.</param>
+        /// <param name="key">The cache key.</param>
+        /// <param name="factory">The factory method to create a new item if the key does not exist in the cache.</param>
+        /// <typeparam name="TItem">The cached item type.</typeparam>
+        /// <returns>The item that was retrieved from the cache or created.</returns>
+        public static TItem GetOrCreateWithLock<TItem>(
+            this IMemoryCache cache,
+            object key,
+            Func<ICacheEntry, TItem> factory)
+        {
+            if (cache.TryGetValue(key, out TItem item))
+            {
+                return item;
+            }
+
+            var lockStr = string.Intern("mutex_" + key.GetHashCode());
+
+            lock (lockStr)
+            {
+                if (cache.TryGetValue(key, out item))
+                {
+                    return item;
+                }
+
+                ICacheEntry entry = cache.CreateEntry(key);
+                item = factory(entry);
+                entry.SetValue(item);
+                entry.Dispose();
+                return item;
+            }
+        }
+    }
+}

--- a/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
+++ b/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
@@ -115,6 +115,10 @@ namespace Medidata.MAuth.Core
             
         private async Task<ApplicationInfo> SendApplicationInfoRequest(ICacheEntry entry, Guid applicationUuid)
         {
+            var logMessage = "Mauth-client requesting from mAuth service application info not available " +
+                             $"in the local cache for app uuid {applicationUuid}.";
+            _logger.LogInformation(logMessage);
+
             var retrier = new MAuthRequestRetrier(_lazyHttpClient.Value);
             var response = await retrier.GetSuccessfulResponse(
                 applicationUuid,
@@ -128,6 +132,9 @@ namespace Medidata.MAuth.Core
                 new MemoryCacheEntryOptions()
                     .SetAbsoluteExpiration(response.Headers.CacheControl?.MaxAge ?? TimeSpan.FromHours(1))
             );
+
+            logMessage = $"Mauth-client application info for app uuid {applicationUuid} cached in memory.";
+            _logger.LogInformation(logMessage);
 
             return result;
         }

--- a/src/Medidata.MAuth.Core/MAuthRequestRetrier.cs
+++ b/src/Medidata.MAuth.Core/MAuthRequestRetrier.cs
@@ -6,23 +6,10 @@ namespace Medidata.MAuth.Core
 {
     internal class MAuthRequestRetrier
     {
-        private readonly HttpClient client;
+        private readonly HttpClient _client;
 
-        public MAuthRequestRetrier(MAuthOptionsBase options)
-        {
-            var signingHandler = new MAuthSigningHandler(options: new MAuthSigningOptions()
-            {
-                ApplicationUuid = options.ApplicationUuid,
-                PrivateKey = options.PrivateKey,
-            },
-            innerHandler: options.MAuthServerHandler ?? new HttpClientHandler()
-            );
-
-            client = new HttpClient(signingHandler)
-            {
-                Timeout = TimeSpan.FromSeconds(options.AuthenticateRequestTimeoutSeconds)
-            };
-        }
+        public MAuthRequestRetrier(HttpClient client) 
+            => _client = client;
 
         public async Task<HttpResponseMessage> GetSuccessfulResponse(Guid applicationUuid,
             Func<Guid, HttpRequestMessage> requestFactory, int requestAttempts)
@@ -50,7 +37,7 @@ namespace Medidata.MAuth.Core
                         nameof(requestFactory)
                     );
 
-                var result = await client.SendAsync(request).ConfigureAwait(continueOnCapturedContext: false);
+                var result = await _client.SendAsync(request).ConfigureAwait(continueOnCapturedContext: false);
 
                 if (result.IsSuccessStatusCode)
                     return result;


### PR DESCRIPTION
### Summary of Issue

If the application info for a particular application uuid has not been cached in memory, it's possible for multiple threads to enter the cache factory method and send outbound requests for the data from the mAuth service.  When there is a high number of concurrent requests executing this logic, there can be significant blocking within the application until the requested info gets cached in memory.

The two concerns are:
- Multiple threads able to call the cache item factory method when application info is not already cached for a specific application uuid
- A new HttpClient (and associated resources) created for each outbound request

### Observed Behavior
During a restart of our application, requests get queued on the web server while the new process starts up.  Once the application has started, it gets the queued requests to process.  This can result in a higher than average number of requests starting to get processed by the application at the same time, before any application info has been cached for the application sending the requests.  This can result in many of the threads making outbound requests to the mAuth service for the same application info, which in turn results in a long period of blocking, followed by timeouts on many of the requests, all with the following call stack:

<img width="1246" alt="Screen Shot 2021-01-21 at 11 13 09 AM" src="https://user-images.githubusercontent.com/16084977/105380970-79d70700-5bdc-11eb-9f7b-2071c8b1a4e3.png">

Once the application info is cached in memory, the application recovers and behaves as expected.  We've observed the blocking last as long as 10-15 minutes before the application recovers.

### How Issue was Addressed

#### Restrict to a single outbound request per application uuid not already cached in memory
- Store the request retrier Task as a Lazy object in the MemoryCache to defer the start of the outbound request until after the request retrier Task has been placed in the cache.
- Implement a version of the GetOrCreate cache extension method that locks based on the cache key, to limit the calls to the cache item factory method to a single thread per key not already in the cache.

#### Reduce number of HttpClient objects (and associated resources) created
- Creation of the HttpClient has been moved up one level, to the MAuthAuthenticator, and that client is passed to each new MAuthRequestRetrier.  The HttpClient is held in a Lazy object, to defer creation until it's needed.

I've reproduced the issue at a smaller scale in our sandbox environment, and no longer see the performance impact with these changes in place.