### PR TITLE
[MCC-652120] Incorporate protocol test suite as submodule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,6 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+# Declare Unix specific filtetypes
+* text eol=lf

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "mauth-protocol-test-suite"]
+	path = mauth-protocol-test-suite
+	url = git@github.com:mdsol/mauth-protocol-test-suite.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mauth-protocol-test-suite"]
 	path = mauth-protocol-test-suite
-	url = git@github.com:mdsol/mauth-protocol-test-suite.git
+	url = https://github.com/mdsol/mauth-protocol-test-suite.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,24 @@
 # Contributing
 
+## Cloning the Repo
+
+This repo contains the submodule `mauth-protocol-test-suite` so requires a flag when initially cloning in order to clone and init submodules.
+
+```
+git clone --recurse-submodules git@github.com:mdsol/mauth-client-ruby.git
+```
+
+If you have already cloned a version of this repo before the submodule was introduced then run
+
+```
+cd mauth-protocol-test-suite
+git submodule update --init
+```
+
+to init the submodule.
+
 ## General Information
-* Clone this repo in your workspace. Checkout latest `develop` branch.
+* Checkout latest `develop` branch.
 * Make new changes or updates into `feature/bugfix` branch.
 * Make sure to add unit tests for it so that there is no breaking changes.
 * Commit and push your branch to compare and create PR against latest `develop` branch.
@@ -11,15 +28,5 @@ To run tests, go the folder `mauth-client-dotnet\tests\Medidata.MAuth.Tests`
 Next, run the tests as:
 
 ```
-dotnet test --filter "Category!=ProtocolTestSuite"
-```
-
-## Running mauth-protocol-test-suite
-To run the mauth-protocol-test-suite clone the latest suite onto your machine and place it in the same parent directory as this repo (or supply the ENV var 
-`TEST_SUITE_PATH` with the path to the test suite relative to this repo).  
-Then navigate to :`mauth-client-dotnet\tests\Medidata.MAuth.Tests`  
-And, run the tests as:
-
-```
-dotnet test --filter "Category=ProtocolTestSuite"
+dotnet test
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 This repo contains the submodule `mauth-protocol-test-suite` so requires a flag when initially cloning in order to clone and init submodules.
 
 ```
-git clone --recurse-submodules git@github.com:mdsol/mauth-client-ruby.git
+git clone --recurse-submodules git@github.com:mdsol/mauth-client-dotnet.git
 ```
 
 If you have already cloned a version of this repo before the submodule was introduced then run

--- a/Medidata.MAuth.sln
+++ b/Medidata.MAuth.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30907.101
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2A4336AA-6F7D-414B-AB2B-81A8F2E82A48}"
 EndProject
@@ -27,7 +27,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{F8B8C2CD-CBAE-42A5-A5FF-2A26E5275941}"
 	ProjectSection(SolutionItems) = preProject
 		build\build.ps1 = build\build.ps1
-		build\common.props = build\common.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Medidata.MAuth.AspNetCore", "src\Medidata.MAuth.AspNetCore\Medidata.MAuth.AspNetCore.csproj", "{1BC50789-3BAE-4D87-B89C-C2658BFF6522}"
@@ -68,5 +67,8 @@ Global
 		{74308221-D7A5-4C15-86D2-62871655C24B} = {2A4336AA-6F7D-414B-AB2B-81A8F2E82A48}
 		{E557F648-6FE1-432E-A8D7-BD00C18E5176} = {2A4336AA-6F7D-414B-AB2B-81A8F2E82A48}
 		{1BC50789-3BAE-4D87-B89C-C2658BFF6522} = {2A4336AA-6F7D-414B-AB2B-81A8F2E82A48}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0A4D3258-5262-45FC-8A21-832CCBBB5878}
 	EndGlobalSection
 EndGlobal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ pull_requests:
 image: Visual Studio 2019
 init:
   - git config --global core.autocrlf true
+install:
+  - git submodule update --init --recursive
 nuget:
   disable_publish_on_pr: true
 build_script:

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -67,7 +67,7 @@ Write-Host "Running unit tests..." -ForegroundColor Cyan
 
 Push-Location -Path .\tests\Medidata.MAuth.Tests
 
-dotnet test --filter "Category!=ProtocolTestSuite"
+dotnet test
 
 Pop-Location
 

--- a/tests/Medidata.MAuth.Tests/ProtocolTestSuite/ProtocolTestSuiteHelper.cs
+++ b/tests/Medidata.MAuth.Tests/ProtocolTestSuite/ProtocolTestSuiteHelper.cs
@@ -10,21 +10,20 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
 {
     public class ProtocolTestSuiteHelper
     {
-        private string _testSuitePath;
         private string _testCasePath;
+        private string _testSuiteModulePath;
 
         public ProtocolTestSuiteHelper()
         {
             var currentDirectory = Environment.CurrentDirectory;
-            _testSuitePath = Environment.GetEnvironmentVariable("TEST_SUITE_PATH") != null
-                ? Environment.GetEnvironmentVariable("TEST_SUITE_PATH")
-                : Path.GetFullPath(Path.Combine(currentDirectory, "../../../../../../mauth-protocol-test-suite"));
-            _testCasePath = Path.Combine(_testSuitePath, "protocols/MWSV2");
+            _testSuiteModulePath = Path.GetFullPath(
+                Path.Combine(currentDirectory, "../../../../../mauth-protocol-test-suite"));
+            _testCasePath = Path.Combine(_testSuiteModulePath, "protocols/MWSV2");
         }
 
         public async Task<SigningConfig> LoadSigningConfig()
         {
-            var configFile = Path.Combine(_testSuitePath, "signing-config.json");
+            var configFile = Path.Combine(_testSuiteModulePath, "signing-config.json");
 
             var signingConfig = await ReadSigningConfigParameters(configFile);
             if (signingConfig is null )return null;
@@ -41,23 +40,14 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
 
         public async Task<string> GetPrivateKey()
         {
-            var filePath = Path.Combine(_testSuitePath, "signing-params/rsa-key");
+            var filePath = Path.Combine(_testSuiteModulePath, "signing-params/rsa-key");
             return Encoding.UTF8.GetString(await ReadAsBytes(filePath));
         }
 
         public async Task<string> GetPublicKey()
         {
-            var publicKeyFilePath = Path.Combine(_testSuitePath, "signing-params/rsa-key-pub");
-
-            // TODO: remove this try catch when "mauth-protocol-test-suite" is added as submodule
-            try
-            {
-                return Encoding.UTF8.GetString(await ReadAsBytes(publicKeyFilePath));
-            }
-            catch (DirectoryNotFoundException)
-            {
-                return null;
-            }
+            var publicKeyFilePath = Path.Combine(_testSuiteModulePath, "signing-params/rsa-key-pub");
+            return Encoding.UTF8.GetString(await ReadAsBytes(publicKeyFilePath));
         }
 
         public async Task<UnSignedRequest> LoadUnsignedRequest(string testCaseName)
@@ -114,16 +104,8 @@ namespace Medidata.MAuth.Tests.ProtocolTestSuite
 
         private async Task<SigningConfig> ReadSigningConfigParameters(string signingConfigJson)
         {
-            // TODO: remove this try catch when "mauth-protocol-test-suite" is added as submodule
-            try
-            {
-                var signingConfigBytes = await ReadAsBytes(signingConfigJson);
-                return JsonConvert.DeserializeObject<SigningConfig>(Encoding.UTF8.GetString(signingConfigBytes));
-            }
-            catch (DirectoryNotFoundException)
-            {
-                return null;
-            }
+            var signingConfigBytes = await ReadAsBytes(signingConfigJson);
+            return JsonConvert.DeserializeObject<SigningConfig>(Encoding.UTF8.GetString(signingConfigBytes));
         }
 
         private async Task<byte[]> ReadAsBytes(string filePath)


### PR DESCRIPTION
[Jira story](https://jira.mdsol.com/browse/MCC-652120)

This PR is for incorporating [mauth protocol test suite](https://github.com/mdsol/mauth-protocol-test-suite) into this "mauth-client-dotnet" repository as submodule.

It includes:

- Add `mauth-protocol-test-suite` as git submodule.
- Update contributing doc.
- Updated and verified all the unit tests run with `dotnet test`.

Please review:
@mdsol/architecture-enablement 

