### PR TITLE
[MCC-805831] Switch key caching to 5 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes in Medidata.MAuth
 
+## v5.1.4
+- **[Core]** Change the fallback behavior of caching from 1 hour to 5 minutes in case when there is no valid caching
+  instruction provided by the MAuth server
+
 ## v5.1.3
 - **[All]** Partially removed target framework multitargeting and specified single target framework for most of the
   packages

--- a/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
+++ b/src/Medidata.MAuth.Core/MAuthAuthenticator.cs
@@ -142,7 +142,7 @@ namespace Medidata.MAuth.Core
 
             entry.SetOptions(
                 new MemoryCacheEntryOptions()
-                    .SetAbsoluteExpiration(response.Headers.CacheControl?.MaxAge ?? TimeSpan.FromHours(1))
+                    .SetAbsoluteExpiration(response.Headers.CacheControl?.MaxAge ?? TimeSpan.FromMinutes(5))
             );
 
             logMessage = $"Mauth-client application info for app uuid {applicationUuid} cached in memory.";

--- a/version.props
+++ b/version.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <Version>5.1.3</Version>
+    <Version>5.1.4</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR switches the current default 1 hour to 5 minutes of the public key caching in case when the MAuth server does not have any (or has invalid) caching instruction headers.

@mdsol/enablement-dotnet 